### PR TITLE
Add sara to export telemetry to local aspire dashboard

### DIFF
--- a/api/Configurations/OpenTelemetryConfiguration.cs
+++ b/api/Configurations/OpenTelemetryConfiguration.cs
@@ -34,6 +34,7 @@ public static class TelemetryConfigurations
             .WithTracing(t =>
             {
                 t.SetSampler(new AlwaysOnSampler())
+                    .SetErrorStatusOnException(true)
                     .SetResourceBuilder(
                         ResourceBuilder
                             .CreateDefault()
@@ -55,27 +56,66 @@ public static class TelemetryConfigurations
                     .AddProcessInstrumentation();
             });
 
-        // Connect to Azure Monitor if connection string is provided
-        var applicationInsightsConnectionString = builder.Configuration[
-            "ApplicationInsights:ConnectionString"
-        ];
+        // Conditionally connect to Azure Monitor
+        var azureMonitorExportEnabled =
+            builder.Configuration.GetValue<bool?>("OpenTelemetry:AzureMonitorExportEnabled")
+            ?? false;
 
-        if (!string.IsNullOrEmpty(applicationInsightsConnectionString))
+        if (azureMonitorExportEnabled)
         {
-            builder
-                .Services.AddOpenTelemetry()
-                .UseAzureMonitor(o =>
-                {
-                    o.ConnectionString = applicationInsightsConnectionString;
-                });
+            var applicationInsightsConnectionString = builder.Configuration[
+                "ApplicationInsights:ConnectionString"
+            ];
+
+            if (!string.IsNullOrEmpty(applicationInsightsConnectionString))
+            {
+                builder
+                    .Services.AddOpenTelemetry()
+                    .UseAzureMonitor(o =>
+                    {
+                        o.ConnectionString = applicationInsightsConnectionString;
+                    });
+            }
         }
 
         // Connect to OpenTelemetry OTLP exporter if endpoint is provided, used for local aspire dashboard
         var openTelemetryEndpoint = builder.Configuration["OpenTelemetry:OtelExporterOtlpEndpoint"];
+        var openTelemetryProtocolSetting = builder.Configuration[
+            "OpenTelemetry:OtelExporterOtlpProtocol"
+        ];
+
+        Console.WriteLine($"OpenTelemetry endpoint: {openTelemetryEndpoint}");
+        Console.WriteLine(
+            $"OpenTelemetry protocol: {openTelemetryProtocolSetting ?? "Not set (using default HttpProtobuf)"}"
+        );
+
         if (!string.IsNullOrWhiteSpace(openTelemetryEndpoint))
         {
             var uri = new Uri(openTelemetryEndpoint);
-            var protocol = OtlpExportProtocol.Grpc;
+            var protocol = OtlpExportProtocol.HttpProtobuf; // Default
+
+            if (!string.IsNullOrWhiteSpace(openTelemetryProtocolSetting))
+            {
+                switch (openTelemetryProtocolSetting.ToLower())
+                {
+                    case "grpc":
+                        protocol = OtlpExportProtocol.Grpc;
+                        Console.WriteLine("Using gRPC protocol for OpenTelemetry export");
+                        break;
+                    case "httpprotobuf":
+                        Console.WriteLine("Using HTTP/Protobuf protocol for OpenTelemetry export");
+                        break;
+                    default:
+                        Console.WriteLine(
+                            $"Unknown protocol '{openTelemetryProtocolSetting}', defaulting to HTTP/Protobuf"
+                        );
+                        break;
+                }
+            }
+            else
+            {
+                Console.WriteLine("Using default HTTP/Protobuf protocol for OpenTelemetry export");
+            }
 
             otel.UseOtlpExporter(protocol, uri);
         }

--- a/api/appsettings.Development.json
+++ b/api/appsettings.Development.json
@@ -28,6 +28,7 @@
     "VisStorageAccount": "saradevstorevis"
   },
   "OpenTelemetry": {
-    "Enabled": true
+    "Enabled": true,
+    "AzureMonitorExportEnabled": true
   }
 }

--- a/api/appsettings.Local.json
+++ b/api/appsettings.Local.json
@@ -33,6 +33,8 @@
   "ArgoWorkflowAnalysisBaseUrl": "http://localhost:8080/trigger-analysis",
   "OpenTelemetry": {
     "Enabled": true,
-    "OtelExporterOtlpEndpoint": "http://localhost:18889"
+    "OtelExporterOtlpEndpoint": "http://localhost:4318",
+    "OtelExporterOtlpProtocol": "httpprotobuf",
+    "AzureMonitorExportEnabled": false
   }
 }


### PR DESCRIPTION
Adds Sara with the same setup as Flotilla, configuring it to send open telemetry data to aspire dashboard when developing locally. 

<img width="371" height="285" alt="image" src="https://github.com/user-attachments/assets/71ebe061-2c25-476a-a42b-4462de4eb85c" />

Also fixes so that azure monitor export has to be explicitly enabled, so local environments does not unintentionally send to azure monitor even though connection string is available. 
