### PR TITLE
Add conditional https redirection for local dev

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -143,7 +143,14 @@ app.UseCors(corsBuilder =>
         .AllowCredentials()
 );
 
-app.UseHttpsRedirection();
+if (!app.Environment.IsEnvironment("Local"))
+{
+    app.UseHttpsRedirection();
+}
+else
+{
+    Console.WriteLine("WARNING: Running without HTTPS redirection (Local only)");
+}
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/api/appsettings.Local.json
+++ b/api/appsettings.Local.json
@@ -30,7 +30,7 @@
     "AnonStorageAccount": "saradevstoreanon",
     "VisStorageAccount": "saradevstorevis"
   },
-  "ArgoWorkflowAnalysisBaseUrl": "http://localhost:8080/trigger-analysis",
+  "ArgoWorkflowAnalysisBaseUrl": "http://localhost:30232/trigger-analysis",
   "OpenTelemetry": {
     "Enabled": true,
     "OtelExporterOtlpEndpoint": "http://localhost:18889"

--- a/mocks/argo_workflow_mock.py
+++ b/mocks/argo_workflow_mock.py
@@ -192,4 +192,4 @@ def notify_workflow_exited(inspection_id):
 
 
 if __name__ == "__main__":
-    app.run(host="127.0.0.1", port=8080)
+    app.run(host="127.0.0.1", port=30232)


### PR DESCRIPTION
It seems like a hassle to get local k8s docker desktop cluster to trust the local self signed certificate for sara. This is a problem when the sara-notifier wants to contact sara on notify endpoints from within the local cluster to outside.

This makes http work in addition to https for local development. 