### PR TITLE
Ensure user input contains no new lines or tabs

### DIFF
--- a/api/Controllers/PlantDataController.cs
+++ b/api/Controllers/PlantDataController.cs
@@ -3,6 +3,7 @@ using api.Controllers.Models;
 using api.Database.Models;
 using api.Services;
 using api.Utilities;
+using Api.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -192,13 +193,14 @@ public class PlantDataController(
         [FromRoute] string inspectionId
     )
     {
+        inspectionId = Sanitize.SanitizeUserInput(inspectionId);
         try
         {
             var plantData = await plantDataService.ReadByInspectionId(inspectionId);
             if (plantData == null)
             {
                 logger.LogWarning(
-                    "No plant data found for InspectionId: {InspectionId}",
+                    "No plant data found for InspectionId: {inspectionId}",
                     inspectionId
                 );
                 return NotFound($"Could not find plant data with inspection id {inspectionId}");
@@ -206,7 +208,7 @@ public class PlantDataController(
 
             var anonymizerWorkflowStatus = plantData.AnonymizerWorkflowStatus;
             logger.LogInformation(
-                "Anonymization workflow status for InspectionId: {InspectionId} is {Status}",
+                "Anonymization workflow status for InspectionId: {inspectionId} is {Status}",
                 inspectionId,
                 anonymizerWorkflowStatus
             );
@@ -216,7 +218,7 @@ public class PlantDataController(
                 case WorkflowStatus.ExitSuccess:
                     var plantDataJson = JsonSerializer.Serialize(plantData, _jsonSerializerOptions);
                     logger.LogInformation(
-                        "Full Plant Data for InspectionId: {InspectionId}: {PlantData}",
+                        "Full Plant Data for InspectionId: {inspectionId}: {PlantData}",
                         inspectionId,
                         plantDataJson
                     );

--- a/api/Utilities/SanitizedInput.cs
+++ b/api/Utilities/SanitizedInput.cs
@@ -1,0 +1,10 @@
+namespace Api.Utilities
+{
+    public static class Sanitize
+    {
+        public static string SanitizeUserInput(string inputString)
+        {
+            return inputString.Replace("\n", "").Replace("\r", "");
+        }
+    }
+}


### PR DESCRIPTION
## Ready for review checklist:

- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.

related to these code scanning alerts: 
[alert 1](https://github.com/equinor/sara/security/code-scanning/34)
[alert 2](https://github.com/equinor/sara/security/code-scanning/33)
[alert 3](https://github.com/equinor/sara/security/code-scanning/32)
[alert 4](https://github.com/equinor/sara/security/code-scanning/28)
[alert 5](https://github.com/equinor/sara/security/code-scanning/27)
[alert 6](https://github.com/equinor/sara/security/code-scanning/26)
