### PR TITLE
Return conflict instead of bad request for AddOrCreateAnalysisMapping

### DIFF
--- a/api.Tests/Controller/AnalysisMappingController.cs
+++ b/api.Tests/Controller/AnalysisMappingController.cs
@@ -102,7 +102,7 @@ namespace api.Controllers.Tests
         }
 
         [Fact]
-        public async Task AddOrCreateAnalysisMapping_BadRequest_WhenAnalysisMappingAlreadyExists()
+        public async Task AddOrCreateAnalysisMapping_Conflict_WhenAnalysisMappingAlreadyExists()
         {
             //Arrange
             await _plantDataService.CreatePlantData(
@@ -128,8 +128,8 @@ namespace api.Controllers.Tests
                 AnalysisType.ConstantLevelOiler
             );
 
-            var statusResult = Assert.IsType<BadRequestObjectResult>(result);
-            Assert.Equal(400, statusResult.StatusCode);
+            var statusResult = Assert.IsType<ConflictObjectResult>(result);
+            Assert.Equal(409, statusResult.StatusCode);
 
             //Assert
             var mapping = await _analysisMappingService.ReadByTagAndInspectionDescription(

--- a/api/Controllers/AnalysisMappingController.cs
+++ b/api/Controllers/AnalysisMappingController.cs
@@ -88,6 +88,7 @@ public class AnalysisMappingController(
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult> AddOrCreateAnalysisMapping(
         [FromRoute] string tagId,
@@ -107,7 +108,7 @@ public class AnalysisMappingController(
         catch (ArgumentException)
         {
             logger.LogError("Analysis type already exists in analysis mapping");
-            return BadRequest("Analysis type already exists in analysis mapping");
+            return Conflict("Analysis type already exists in analysis mapping");
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Closes #208 

## Ready for review checklist:

- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.
