### PR TITLE
Fix bug do not change file ext of preprocessed blob location

### DIFF
--- a/api/Services/BlobService.cs
+++ b/api/Services/BlobService.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using api.Database.Models;
 using Azure;
 using Azure.Storage.Blobs;
@@ -20,6 +20,11 @@ namespace api.Services
         );
 
         public BlobStorageLocation CreateAnonymizedBlobStorageLocation(
+            string blobContainer,
+            string blobName
+        );
+
+        public BlobStorageLocation CreatePreProcessedBlobStorageLocation(
             string blobContainer,
             string blobName
         );
@@ -141,6 +146,27 @@ namespace api.Services
                 StorageAccount = anonymizedStorageAccount,
                 BlobContainer = blobContainer,
                 BlobName = jpgBlobName,
+            };
+        }
+
+        public BlobStorageLocation CreatePreProcessedBlobStorageLocation(
+            string blobContainer,
+            string blobName
+        )
+        {
+            var anonymizedStorageAccount = configuration.GetSection("Storage")[
+                "AnonStorageAccount"
+            ];
+            if (string.IsNullOrEmpty(anonymizedStorageAccount))
+            {
+                throw new InvalidOperationException("AnonStorageAccount is not configured.");
+            }
+
+            return new BlobStorageLocation
+            {
+                StorageAccount = anonymizedStorageAccount,
+                BlobContainer = blobContainer,
+                BlobName = blobName,
             };
         }
 

--- a/api/Services/PlantDataService.cs
+++ b/api/Services/PlantDataService.cs
@@ -222,7 +222,8 @@ public class PlantDataService(
             );
 
             var preProcessedBlobName = BlobService.ReplaceFileEnding(rawBlobName, ".fff");
-            var preProcessedBlobStorageLocation = blobService.CreateAnonymizedBlobStorageLocation(
+
+            var preProcessedBlobStorageLocation = blobService.CreatePreProcessedBlobStorageLocation(
                 rawBlobContainer,
                 preProcessedBlobName
             );


### PR DESCRIPTION
## Ready for review checklist:

- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.

The bug:
CreateAnonymizedStorageLocation was changing the file-ending from .fff to .jpg for preprocessedblobstorage location

This is not intended as this file should just be copied over. 