### PR TITLE
Use Guid as IDs in database instead of string Ids

### DIFF
--- a/api.Tests/Controller/TriggerAnalysisController.cs
+++ b/api.Tests/Controller/TriggerAnalysisController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using api.Database.Models;
 using api.Services;
@@ -31,7 +32,7 @@ namespace api.Controllers.Tests
         public async Task TriggerAnonymizer_ReturnsNotFound_WhenPlantDataDoesNotExist()
         {
             //Arrange
-            var plantDataId = "nonexistent-id";
+            var plantDataId = Guid.NewGuid();
             _plantDataServiceMock
                 .Setup(service => service.ReadById(plantDataId))
                 .ReturnsAsync((PlantData?)null);
@@ -47,7 +48,7 @@ namespace api.Controllers.Tests
         public async Task TriggerAnonymizer_ReturnsConflict_WhenWorkflowsAlreadyTriggered()
         {
             //Arrange
-            var plantDataId = "dummy-id";
+            var plantDataId = Guid.NewGuid();
             _plantDataServiceMock
                 .Setup(service => service.ReadById(plantDataId))
                 .ReturnsAsync(
@@ -90,7 +91,7 @@ namespace api.Controllers.Tests
         public async Task TriggerAnonymizer_TriggersWorkflow_WhenPlantDataExistsAndNotStarted()
         {
             //Arrange
-            var plantDataId = "dummy-id";
+            var plantDataId = Guid.NewGuid();
 
             var plantData = new PlantData
             {
@@ -133,7 +134,7 @@ namespace api.Controllers.Tests
         public async Task TriggerAnalysis_ReturnsNotFound_WhenPlantDataDoesNotExist()
         {
             // Arrange
-            var plantDataId = "missing-id";
+            var plantDataId = Guid.NewGuid();
 
             _plantDataServiceMock
                 .Setup(service => service.ReadById(plantDataId))
@@ -151,7 +152,7 @@ namespace api.Controllers.Tests
         public async Task TriggerAnalysis_ReturnsOk_WhenServiceSucceeds()
         {
             // Arrange
-            var plantDataId = "dummy-id";
+            var plantDataId = Guid.NewGuid();
 
             _plantDataServiceMock
                 .Setup(service => service.ReadById(plantDataId))
@@ -193,7 +194,7 @@ namespace api.Controllers.Tests
         public async Task TriggerAnalysis_ReturnsConflict_WhenAnonymizationStarted()
         {
             // Arrange
-            var plantDataId = "dummy-id";
+            var plantDataId = Guid.NewGuid();
 
             _plantDataServiceMock
                 .Setup(service => service.ReadById(plantDataId))
@@ -236,7 +237,7 @@ namespace api.Controllers.Tests
         public async Task TriggerAnalysis_ReturnsOk_WhenAnonymizationExitSuccessAndNoConfiguredAnalyses()
         {
             // Arrange
-            var plantDataId = "dummy-id";
+            var plantDataId = Guid.NewGuid();
 
             _plantDataServiceMock
                 .Setup(service => service.ReadById(plantDataId))
@@ -279,7 +280,7 @@ namespace api.Controllers.Tests
         public async Task TriggerAnalysis_ReturnsOk_WhenAnonymizationExitSuccessAndConfiguredCLOEAnalysis()
         {
             // Arrange
-            var plantDataId = "dummy-id";
+            var plantDataId = Guid.NewGuid();
 
             _plantDataServiceMock
                 .Setup(service => service.ReadById(plantDataId))

--- a/api/Controllers/AnalysisMappingController.cs
+++ b/api/Controllers/AnalysisMappingController.cs
@@ -56,7 +56,7 @@ public class AnalysisMappingController(
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<AnalysisMapping>> GetAnalysisById([FromRoute] string id)
+    public async Task<ActionResult<AnalysisMapping>> GetAnalysisById([FromRoute] Guid id)
     {
         try
         {
@@ -150,7 +150,7 @@ public class AnalysisMappingController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult<AnalysisMapping>> AddAnalysisTypeToMapping(
-        [FromRoute] string analysisMappingId,
+        [FromRoute] Guid analysisMappingId,
         [FromRoute] AnalysisType analysisType
     )
     {
@@ -196,7 +196,7 @@ public class AnalysisMappingController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult<AnalysisMapping>> RemoveAnalysisFromMapping(
-        [FromRoute] string analysisMappingId,
+        [FromRoute] Guid analysisMappingId,
         [FromRoute] AnalysisType analysisType
     )
     {
@@ -236,7 +236,7 @@ public class AnalysisMappingController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult<AnalysisMapping>> RemoveAnalysisFromMapping(
-        [FromRoute] string analysisMappingId
+        [FromRoute] Guid analysisMappingId
     )
     {
         try

--- a/api/Controllers/Models/PlantDataResponse.cs
+++ b/api/Controllers/Models/PlantDataResponse.cs
@@ -8,7 +8,7 @@ namespace api.Controllers.Models
 {
     public class PlantDataResponse
     {
-        public string id { get; set; }
+        public Guid id { get; set; }
 
         [JsonConstructor]
         public PlantDataResponse() { }

--- a/api/Controllers/PlantDataController.cs
+++ b/api/Controllers/PlantDataController.cs
@@ -105,7 +105,7 @@ public class PlantDataController(
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<PlantData>> GetPlantDataById([FromRoute] string id)
+    public async Task<ActionResult<PlantData>> GetPlantDataById([FromRoute] Guid id)
     {
         try
         {

--- a/api/Controllers/TriggerAnalysisController.cs
+++ b/api/Controllers/TriggerAnalysisController.cs
@@ -27,7 +27,7 @@ public class TriggerAnalysisController(
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> TriggerAnonymizer([FromRoute] string plantDataId)
+    public async Task<IActionResult> TriggerAnonymizer([FromRoute] Guid plantDataId)
     {
         var plantData = await plantDataService.ReadById(plantDataId);
         if (plantData == null)
@@ -66,10 +66,8 @@ public class TriggerAnalysisController(
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> TriggerAnalysis([FromRoute] string plantDataId)
+    public async Task<IActionResult> TriggerAnalysis([FromRoute] Guid plantDataId)
     {
-        plantDataId = Sanitize.SanitizeUserInput(plantDataId);
-
         try
         {
             var plantData = await plantDataService.ReadById(plantDataId);
@@ -85,7 +83,10 @@ public class TriggerAnalysisController(
 
             if (plantData.Anonymization?.Status == WorkflowStatus.NotStarted)
             {
-                await argoWorkflowService.TriggerAnonymizer(plantDataId, plantData.Anonymization);
+                await argoWorkflowService.TriggerAnonymizer(
+                    plantData.InspectionId,
+                    plantData.Anonymization
+                );
                 return Ok(
                     "Triggering anonymization workflow which will trigger analysis workflows."
                 );

--- a/api/Database/Models/AnalysisMapping.cs
+++ b/api/Database/Models/AnalysisMapping.cs
@@ -19,7 +19,7 @@ public class AnalysisMapping(
 {
     [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-    public string Id { get; set; }
+    public Guid Id { get; set; }
 
     [Required]
     public string Tag { get; set; } = tag;

--- a/api/Database/Models/PlantData.cs
+++ b/api/Database/Models/PlantData.cs
@@ -9,7 +9,7 @@ public class PlantData
 {
     [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-    public string Id { get; set; }
+    public Guid Id { get; set; }
 
     [Required]
     public required string InspectionId { get; set; }

--- a/api/Database/Models/Workflow.cs
+++ b/api/Database/Models/Workflow.cs
@@ -32,7 +32,7 @@ public abstract class Workflow
 {
     [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-    public string Id { get; set; }
+    public Guid Id { get; set; }
 
     [Required]
     public required BlobStorageLocation SourceBlobStorageLocation { get; set; }

--- a/api/Migrations/20260330130858_AddUseGuid.Designer.cs
+++ b/api/Migrations/20260330130858_AddUseGuid.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using api.Database.Context;
@@ -11,9 +12,11 @@ using api.Database.Context;
 namespace api.Migrations
 {
     [DbContext(typeof(SaraDbContext))]
-    partial class SaraDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260330130858_AddUseGuid")]
+    partial class AddUseGuid
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20260330130858_AddUseGuid.cs
+++ b/api/Migrations/20260330130858_AddUseGuid.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUseGuid : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Drop FK constraints before altering column types
+            migrationBuilder.Sql(@"
+                ALTER TABLE ""PlantData"" DROP CONSTRAINT IF EXISTS ""FK_PlantData_Anonymization_AnonymizationId"";
+                ALTER TABLE ""PlantData"" DROP CONSTRAINT IF EXISTS ""FK_PlantData_CLOEAnalysis_CLOEAnalysisId"";
+                ALTER TABLE ""PlantData"" DROP CONSTRAINT IF EXISTS ""FK_PlantData_FencillaAnalysis_FencillaAnalysisId"";
+                ALTER TABLE ""PlantData"" DROP CONSTRAINT IF EXISTS ""FK_PlantData_ThermalReading_ThermalReadingAnalysisId"";
+            ");
+
+            // Convert all ID and FK columns from text to uuid using explicit USING cast
+            migrationBuilder.Sql(@"
+                ALTER TABLE ""PlantData"" ALTER COLUMN ""AnonymizationId"" DROP DEFAULT;
+                ALTER TABLE ""AnalysisMapping"" ALTER COLUMN ""Id"" TYPE uuid USING ""Id""::uuid;
+                ALTER TABLE ""Anonymization"" ALTER COLUMN ""Id"" TYPE uuid USING ""Id""::uuid;
+                ALTER TABLE ""CLOEAnalysis"" ALTER COLUMN ""Id"" TYPE uuid USING ""Id""::uuid;
+                ALTER TABLE ""FencillaAnalysis"" ALTER COLUMN ""Id"" TYPE uuid USING ""Id""::uuid;
+                ALTER TABLE ""ThermalReading"" ALTER COLUMN ""Id"" TYPE uuid USING ""Id""::uuid;
+                ALTER TABLE ""PlantData"" ALTER COLUMN ""Id"" TYPE uuid USING ""Id""::uuid;
+                ALTER TABLE ""PlantData"" ALTER COLUMN ""AnonymizationId"" TYPE uuid USING ""AnonymizationId""::uuid;
+                ALTER TABLE ""PlantData"" ALTER COLUMN ""CLOEAnalysisId"" TYPE uuid USING ""CLOEAnalysisId""::uuid;
+                ALTER TABLE ""PlantData"" ALTER COLUMN ""FencillaAnalysisId"" TYPE uuid USING ""FencillaAnalysisId""::uuid;
+                ALTER TABLE ""PlantData"" ALTER COLUMN ""ThermalReadingAnalysisId"" TYPE uuid USING ""ThermalReadingAnalysisId""::uuid;
+            ");
+
+            // Re-add FK constraints
+            migrationBuilder.Sql(@"
+                ALTER TABLE ""PlantData"" ADD CONSTRAINT ""FK_PlantData_Anonymization_AnonymizationId""
+                    FOREIGN KEY (""AnonymizationId"") REFERENCES ""Anonymization"" (""Id"");
+                ALTER TABLE ""PlantData"" ADD CONSTRAINT ""FK_PlantData_CLOEAnalysis_CLOEAnalysisId""
+                    FOREIGN KEY (""CLOEAnalysisId"") REFERENCES ""CLOEAnalysis"" (""Id"");
+                ALTER TABLE ""PlantData"" ADD CONSTRAINT ""FK_PlantData_FencillaAnalysis_FencillaAnalysisId""
+                    FOREIGN KEY (""FencillaAnalysisId"") REFERENCES ""FencillaAnalysis"" (""Id"");
+                ALTER TABLE ""PlantData"" ADD CONSTRAINT ""FK_PlantData_ThermalReading_ThermalReadingAnalysisId""
+                    FOREIGN KEY (""ThermalReadingAnalysisId"") REFERENCES ""ThermalReading"" (""Id"");
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Drop FK constraints before altering column types
+            migrationBuilder.Sql(@"
+                ALTER TABLE ""PlantData"" DROP CONSTRAINT IF EXISTS ""FK_PlantData_Anonymization_AnonymizationId"";
+                ALTER TABLE ""PlantData"" DROP CONSTRAINT IF EXISTS ""FK_PlantData_CLOEAnalysis_CLOEAnalysisId"";
+                ALTER TABLE ""PlantData"" DROP CONSTRAINT IF EXISTS ""FK_PlantData_FencillaAnalysis_FencillaAnalysisId"";
+                ALTER TABLE ""PlantData"" DROP CONSTRAINT IF EXISTS ""FK_PlantData_ThermalReading_ThermalReadingAnalysisId"";
+            ");
+
+            // Convert all columns back from uuid to text
+            migrationBuilder.Sql(@"
+                ALTER TABLE ""AnalysisMapping"" ALTER COLUMN ""Id"" TYPE text USING ""Id""::text;
+                ALTER TABLE ""Anonymization"" ALTER COLUMN ""Id"" TYPE text USING ""Id""::text;
+                ALTER TABLE ""CLOEAnalysis"" ALTER COLUMN ""Id"" TYPE text USING ""Id""::text;
+                ALTER TABLE ""FencillaAnalysis"" ALTER COLUMN ""Id"" TYPE text USING ""Id""::text;
+                ALTER TABLE ""ThermalReading"" ALTER COLUMN ""Id"" TYPE text USING ""Id""::text;
+                ALTER TABLE ""PlantData"" ALTER COLUMN ""Id"" TYPE text USING ""Id""::text;
+                ALTER TABLE ""PlantData"" ALTER COLUMN ""AnonymizationId"" TYPE text USING ""AnonymizationId""::text;
+                ALTER TABLE ""PlantData"" ALTER COLUMN ""CLOEAnalysisId"" TYPE text USING ""CLOEAnalysisId""::text;
+                ALTER TABLE ""PlantData"" ALTER COLUMN ""FencillaAnalysisId"" TYPE text USING ""FencillaAnalysisId""::text;
+                ALTER TABLE ""PlantData"" ALTER COLUMN ""ThermalReadingAnalysisId"" TYPE text USING ""ThermalReadingAnalysisId""::text;
+            ");
+
+            // Re-add FK constraints
+            migrationBuilder.Sql(@"
+                ALTER TABLE ""PlantData"" ADD CONSTRAINT ""FK_PlantData_Anonymization_AnonymizationId""
+                    FOREIGN KEY (""AnonymizationId"") REFERENCES ""Anonymization"" (""Id"");
+                ALTER TABLE ""PlantData"" ADD CONSTRAINT ""FK_PlantData_CLOEAnalysis_CLOEAnalysisId""
+                    FOREIGN KEY (""CLOEAnalysisId"") REFERENCES ""CLOEAnalysis"" (""Id"");
+                ALTER TABLE ""PlantData"" ADD CONSTRAINT ""FK_PlantData_FencillaAnalysis_FencillaAnalysisId""
+                    FOREIGN KEY (""FencillaAnalysisId"") REFERENCES ""FencillaAnalysis"" (""Id"");
+                ALTER TABLE ""PlantData"" ADD CONSTRAINT ""FK_PlantData_ThermalReading_ThermalReadingAnalysisId""
+                    FOREIGN KEY (""ThermalReadingAnalysisId"") REFERENCES ""ThermalReading"" (""Id"");
+            ");
+        }
+    }
+}

--- a/api/Services/AnalysisMappingService.cs
+++ b/api/Services/AnalysisMappingService.cs
@@ -12,7 +12,7 @@ public interface IAnalysisMappingService
         AnalysisMappingParameters parameters
     );
 
-    public Task<AnalysisMapping?> ReadById(string id);
+    public Task<AnalysisMapping?> ReadById(Guid id);
 
     public Task<AnalysisMapping?> ReadByTagAndInspectionDescription(
         string tagId,
@@ -33,11 +33,11 @@ public interface IAnalysisMappingService
     public Task<List<AnalysisType>> GetAnalysesToBeRun(string tagId, string inspectionDescription);
 
     public Task<AnalysisMapping> RemoveAnalysisTypeFromMapping(
-        string analysisMappingId,
+        Guid analysisMappingId,
         AnalysisType analysisType
     );
 
-    public Task RemoveAnalysisMapping(string analysisMappingId);
+    public Task RemoveAnalysisMapping(Guid analysisMappingId);
 
     public Task<AnalysisMapping> AddOrCreateAnalysisMapping(
         string tagId,
@@ -75,9 +75,9 @@ public class AnalysisMappingService(SaraDbContext context, ILogger<AnalysisMappi
         );
     }
 
-    public async Task<AnalysisMapping?> ReadById(string id)
+    public async Task<AnalysisMapping?> ReadById(Guid id)
     {
-        return await context.AnalysisMapping.FirstOrDefaultAsync(i => i.Id.Equals(id));
+        return await context.AnalysisMapping.FirstOrDefaultAsync(i => i.Id == id);
     }
 
     public async Task<AnalysisMapping?> ReadByTagAndInspectionDescription(
@@ -173,7 +173,7 @@ public class AnalysisMappingService(SaraDbContext context, ILogger<AnalysisMappi
     }
 
     public async Task<AnalysisMapping> RemoveAnalysisTypeFromMapping(
-        string analysisMappingId,
+        Guid analysisMappingId,
         AnalysisType analysisType
     )
     {
@@ -196,7 +196,7 @@ public class AnalysisMappingService(SaraDbContext context, ILogger<AnalysisMappi
         return analysisMapping;
     }
 
-    public async Task RemoveAnalysisMapping(string analysisMappingId)
+    public async Task RemoveAnalysisMapping(Guid analysisMappingId)
     {
         var analysisMapping =
             await ReadById(analysisMappingId)

--- a/api/Services/PlantDataService.cs
+++ b/api/Services/PlantDataService.cs
@@ -9,7 +9,7 @@ public interface IPlantDataService
 {
     public Task<PagedList<PlantData>> GetPlantData(QueryParameters parameters);
 
-    public Task<PlantData?> ReadById(string id);
+    public Task<PlantData?> ReadById(Guid id);
 
     public Task<List<PlantData>> ReadByTagIdAndInspectionDescription(
         string tagId,
@@ -89,14 +89,14 @@ public class PlantDataService(
         );
     }
 
-    public async Task<PlantData?> ReadById(string id)
+    public async Task<PlantData?> ReadById(Guid id)
     {
         return await context
             .PlantData.Include(plantData => plantData.Anonymization)
             .Include(plantData => plantData.CLOEAnalysis)
             .Include(plantData => plantData.FencillaAnalysis)
             .Include(plantData => plantData.ThermalReadingAnalysis)
-            .FirstOrDefaultAsync(i => i.Id.Equals(id));
+            .FirstOrDefaultAsync(i => i.Id == id);
     }
 
     public async Task<bool> ExistsByInspectionId(string inspectionId)


### PR DESCRIPTION
Migration manual edits:
EF Core's auto-generated AlterColumn calls can't specify PostgreSQL's required USING cast when changing column types. The migration was rewritten to use raw SQL that: drops the 4 FK constraints on PlantData, converts all 10 affected columns from text to uuid using USING "col"::uuid, then re-adds the FK constraints. This is safe because all existing IDs are already UUID-format strings generated by EF Core and gen_random_uuid().

## Ready for review checklist:

- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.
