### PR TITLE
Replace backend lint and test workflow with centralized armada workflow

### DIFF
--- a/.github/workflows/backend_lint_and_test.yml
+++ b/.github/workflows/backend_lint_and_test.yml
@@ -12,51 +12,11 @@ on:
       - main
 
 jobs:
-  build_api:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-
-      - name: Set up .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
-        with:
-          dotnet-version: "10.0.x"
-      - name: Build project and dependencies
-        working-directory: ./api
-        run: dotnet build
-
-  test_api:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-
-      - name: Set up .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
-        with:
-          dotnet-version: "10.0.x"
-
-      - name: Build project and dependencies
-        working-directory: ./api.Tests
-        run: dotnet build -warnaserror
-
-      - name: Run tests
-        working-directory: ./api.Tests
-        run: dotnet test
-
-  check_formatting:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
-        with:
-          dotnet-version: "10.0.x"
-
-      - name: Run csharpier format
-        working-directory: ./api
-        run: |
-          dotnet tool restore
-          dotnet csharpier . --check
+  api:
+    permissions:
+      contents: read
+    uses: equinor/armada/.github/workflows/test_and_lint_dotnet_package.yml@main
+    with:
+      build_directory: api
+      test_directory: api.Tests
+      format_directory: api

--- a/.github/workflows/backend_lint_and_test.yml
+++ b/.github/workflows/backend_lint_and_test.yml
@@ -12,51 +12,11 @@ on:
       - main
 
 jobs:
-  build_api:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-
-      - name: Set up .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
-        with:
-          dotnet-version: "10.0.x"
-      - name: Build project and dependencies
-        working-directory: ./api
-        run: dotnet build
-
-  test_api:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-
-      - name: Set up .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
-        with:
-          dotnet-version: "10.0.x"
-
-      - name: Build project and dependencies
-        working-directory: ./api.Tests
-        run: dotnet build -warnaserror
-
-      - name: Run tests
-        working-directory: ./api.Tests
-        run: dotnet test
-
-  check_formatting:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
-        with:
-          dotnet-version: "10.0.x"
-
-      - name: Run csharpier format
-        working-directory: ./api
-        run: |
-          dotnet tool restore
-          dotnet csharpier check .
+  api:
+    permissions:
+      contents: read
+    uses: equinor/armada/.github/workflows/test_and_lint_dotnet_package.yml@main
+    with:
+      build_directory: api
+      test_directory: api.Tests
+      format_directory: api


### PR DESCRIPTION
## Summary

Replaces the local `backend_lint_and_test.yml` workflow (3 inline jobs) with a single call to the new centralized `test_and_lint_dotnet_package.yml` reusable workflow from `equinor/armada`.

Depends on https://github.com/equinor/armada/pull/23 being merged first.

## Changes

- **Replaced** the three inline jobs (`build_api`, `test_api`, `check_formatting`) with a single reusable workflow call
- All three checks (build, test with `-warnaserror`, CSharpier format check) continue to run in parallel as before
- Uses separate directories matching sara's project structure:
  - `build_directory: api` (for `dotnet build`)
  - `test_directory: api.Tests` (for `dotnet build -warnaserror` and `dotnet test`)
  - `format_directory: api` (for CSharpier check)
- Explicit `permissions: contents: read` at both top-level and job-level

## Before / After

**Before**: 62 lines, 3 inline jobs with duplicated checkout/setup-dotnet steps
**After**: 22 lines, 1 reusable workflow call