### PR TITLE
Add integration test workflow for sara

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -1,0 +1,29 @@
+name: Run integration tests
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: "dev or latest"
+        required: true
+        default: latest
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  run-integration-tests:
+    uses: equinor/armada/.github/workflows/run_integration_tests.yml@main
+    with:
+      lane: ${{ github.event_name == 'push' && 'dev'
+            || github.event_name == 'release' && 'latest'
+            || github.event_name == 'workflow_dispatch' && inputs.lane
+            || 'latest' }}
+
+    secrets:
+      INTEGRATION_TEST_AZURE_CLIENT_SECRET: ${{ secrets.INTEGRATION_TEST_AZURE_CLIENT_SECRET }}


### PR DESCRIPTION
## Summary
- Add a caller workflow that runs armada's reusable integration tests on push to main, release publish, and manual dispatch
- Follows the same pattern used in flotilla

## Prerequisites
- The `INTEGRATION_TEST_AZURE_CLIENT_SECRET` secret must be configured in this repository's Actions secrets