### PR TITLE
Add AGENTS.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ bld/
 node_modules/
 api/wwwroot/
 *.tsbuildinfo
+
+AGENTS.md


### PR DESCRIPTION
Adds `AGENTS.md` to `.gitignore` so that local agent instruction files are not tracked by git.