### PR TITLE
Update Node.js 20 actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/frontend_lint_and_test.yml
+++ b/.github/workflows/frontend_lint_and_test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b307475762933b98ed359c036b0e51f26b63b74b #v5
         with:
           version: latest
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary

- Update `pnpm/action-setup` from unpinned `@v4` (node20) to SHA-pinned `@v5` (node24)

Affected workflow: `frontend_lint_and_test.yml`

## Why

Node.js 20 actions are deprecated and will be forced to run on Node.js 24 starting June 2, 2026. Node.js 20 will be removed from runners on September 16, 2026.

## Breaking changes

None. `pnpm/action-setup` v5 only changes the Node.js runtime — inputs and behavior are identical to v4.