### PR TITLE
Reduce log level on image fetching

### DIFF
--- a/api/Controllers/PlantDataController.cs
+++ b/api/Controllers/PlantDataController.cs
@@ -196,7 +196,7 @@ public class PlantDataController(
             }
 
             var anonymizerWorkflowStatus = plantData.Anonymization.Status;
-            logger.LogInformation(
+            logger.LogDebug(
                 "Anonymization workflow status for InspectionId: {inspectionId} is {Status}",
                 inspectionId,
                 anonymizerWorkflowStatus
@@ -206,7 +206,7 @@ public class PlantDataController(
             {
                 case WorkflowStatus.ExitSuccess:
                     var plantDataJson = JsonSerializer.Serialize(plantData, _jsonSerializerOptions);
-                    logger.LogInformation(
+                    logger.LogDebug(
                         "Full Plant Data for InspectionId: {inspectionId}: {PlantData}",
                         inspectionId,
                         plantDataJson


### PR DESCRIPTION
Currently there is a lot of logging when anyone is looking at missions in flotilla webpage. This floods the logs and makes it difficult to follow any other logs

## Ready for review checklist:

- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.
