### PR TITLE
fix(api): sanitize user input in PlantDataService log entries

### DIFF
--- a/api/Services/PlantDataService.cs
+++ b/api/Services/PlantDataService.cs
@@ -205,6 +205,11 @@ public class PlantDataService(
         string? robotName = null
     )
     {
+        inspectionId = Sanitize.SanitizeUserInput(inspectionId);
+        installationCode = Sanitize.SanitizeUserInput(installationCode);
+        tagID = Sanitize.SanitizeUserInput(tagID);
+        inspectionDescription = Sanitize.SanitizeUserInput(inspectionDescription);
+
         List<AnalysisType> analysisToBeRun;
         try
         {


### PR DESCRIPTION
## Summary

Sanitize user-controlled values (`InspectionId`, `InstallationCode`, `TagId`, `InspectionDescription`) at the top of `PlantDataService.CreatePlantData` using the existing `Sanitize.SanitizeUserInput` helper, mirroring the pattern used in the Flotilla repository (e.g. `RobotService.UpdateCurrentMissionId`).

Addresses CodeQL code-scanning alerts:

- [#66](https://github.com/equinor/sara/security/code-scanning/66) — `inspectionId` at `api/Services/PlantDataService.cs:217`
- [#67](https://github.com/equinor/sara/security/code-scanning/67) — `tagID` at `api/Services/PlantDataService.cs:218`
- [#68](https://github.com/equinor/sara/security/code-scanning/68) — `inspectionDescription` at `api/Services/PlantDataService.cs:219`
- [#69](https://github.com/equinor/sara/security/code-scanning/69) — `inspectionId` at `api/Services/PlantDataService.cs:288`

## Why

`PlantDataController.CreatePlantData` already calls `Sanitize.SanitizeUserInput(request)` (`api/Utilities/SanitizedInput.cs`), which strips `\r` and `\n` from these fields. However, CodeQL's `cs/log-forging` taint analysis does not follow the custom sanitizer across method boundaries, so it flags every downstream log call that includes these values as a sink.

Re-applying the sanitizer at the service entry point keeps the data-flow local and recognized by the analysis, and matches the convention used in Flotilla (`backend/api/Services/RobotService.cs`, `backend/api/Services/PointillaService.cs`).


## Ready for review checklist:

- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.
