### PR TITLE
chore(ci): set explicit GITHUB_TOKEN permissions for migration validation workflow

### DIFF
--- a/.github/workflows/validate_dotnet_migrations_against_temp_db.yml
+++ b/.github/workflows/validate_dotnet_migrations_against_temp_db.yml
@@ -6,6 +6,9 @@ on:
       - 'api/**'
       - '.github/workflows/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate_dotnet_migrations_against_temp_db:
     uses: equinor/armada/.github/workflows/validate_dotnet_migrations_against_temp_db.yml@main


### PR DESCRIPTION
## Summary

Add an explicit top-level `permissions:` block to `.github/workflows/validate_dotnet_migrations_against_temp_db.yml`, scoped to `contents: read`, the minimum required for the workflow.

Addresses CodeQL code-scanning alert:

- [#70](https://github.com/equinor/sara/security/code-scanning/70) — `actions/missing-workflow-permissions`

## Why

By default, the `GITHUB_TOKEN` is granted whatever the repository default is. CodeQL recommends every workflow declare an explicit `permissions:` block to enforce the principle of least privilege.

This workflow is a thin caller of the reusable workflow at `equinor/armada/.github/workflows/validate_dotnet_migrations_against_temp_db.yml@main`. Its only operations are:

- `actions/checkout` (needs `contents: read`)
- spinning up an ephemeral postgres container
- running `dotnet ef` migrations against it

No GitHub API writes (no PR comments, no releases, no package writes, no OIDC). `contents: read` is therefore the correct minimum scope and matches the rule's recommended starting point.

## What changed

Added at the top of `.github/workflows/validate_dotnet_migrations_against_temp_db.yml`:

```yaml
permissions:
  contents: read
```

## Verification

- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Workflow logic unchanged; only `GITHUB_TOKEN` scope is restricted.

## Ready for review checklist:

- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.
