### PR TITLE
Use federated credentials when running in cloud

### DIFF
--- a/api/Configurations/CustomServiceConfigurations.cs
+++ b/api/Configurations/CustomServiceConfigurations.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
 using api.Database.Context;
 using Api.Database.Context;
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi;
@@ -10,6 +12,109 @@ namespace api.Configurations;
 
 public static class CustomServiceConfigurations
 {
+    /// <summary>
+    /// Build a <see cref="TokenCredential"/> for authenticating against Azure resources.
+    ///
+    /// The set of credential types to try is configured via
+    /// <c>AzureAd:AllowedAuthMethods</c>, an ordered list whose entries may be
+    /// <c>"WorkloadIdentity"</c> and/or <c>"ClientSecret"</c> (case-insensitive). The
+    /// order of the list determines the order in which credentials are tried when more
+    /// than one method is enabled (i.e. it controls the order inside the resulting
+    /// <see cref="ChainedTokenCredential"/>).
+    ///
+    /// In cloud (AKS with Azure Workload Identity), set
+    /// <c>"AllowedAuthMethods": [ "WorkloadIdentity" ]</c> and rely on the standard
+    /// <c>AZURE_CLIENT_ID</c>, <c>AZURE_TENANT_ID</c>, <c>AZURE_FEDERATED_TOKEN_FILE</c>
+    /// and <c>AZURE_AUTHORITY_HOST</c> environment variables injected by the
+    /// azure-workload-identity mutating webhook.
+    ///
+    /// For local development (and CI) set e.g.
+    /// <c>"AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret" ]</c> together with
+    /// <c>AzureAd:ClientSecret</c> (or <c>AZURE_CLIENT_SECRET</c>). When environment
+    /// variables are used, the .NET configuration array binding pattern is e.g.
+    /// <c>AzureAd__AllowedAuthMethods__0=ClientSecret</c>.
+    /// </summary>
+    public static TokenCredential CreateCredential(IConfiguration config)
+    {
+        string? tenantId = config["AzureAd:TenantId"];
+        string? clientId = config["AzureAd:ClientId"];
+        string? clientSecret = config["AzureAd:ClientSecret"];
+
+        tenantId ??= config["AZURE_TENANT_ID"];
+        clientId ??= config["AZURE_CLIENT_ID"];
+        clientSecret ??= config["AZURE_CLIENT_SECRET"];
+
+        string[] allowedAuthMethods =
+            config.GetSection("AzureAd:AllowedAuthMethods").Get<string[]>() ?? [];
+        if (allowedAuthMethods.Length == 0)
+        {
+            allowedAuthMethods = ["WorkloadIdentity"];
+        }
+
+        var credentials = new List<TokenCredential>();
+        var activated = new List<string>();
+
+        foreach (string method in allowedAuthMethods)
+        {
+            if (string.Equals(method, "WorkloadIdentity", StringComparison.OrdinalIgnoreCase))
+            {
+                var workloadOptions = new WorkloadIdentityCredentialOptions();
+                if (!string.IsNullOrWhiteSpace(clientId))
+                    workloadOptions.ClientId = clientId;
+                if (!string.IsNullOrWhiteSpace(tenantId))
+                    workloadOptions.TenantId = tenantId;
+
+                credentials.Add(new WorkloadIdentityCredential(workloadOptions));
+                activated.Add("WorkloadIdentityCredential");
+            }
+            else if (string.Equals(method, "ClientSecret", StringComparison.OrdinalIgnoreCase))
+            {
+                if (
+                    !string.IsNullOrWhiteSpace(tenantId)
+                    && !string.IsNullOrWhiteSpace(clientId)
+                    && !string.IsNullOrWhiteSpace(clientSecret)
+                    && !clientSecret.StartsWith("Fill in", StringComparison.OrdinalIgnoreCase)
+                )
+                {
+                    credentials.Add(new ClientSecretCredential(tenantId, clientId, clientSecret));
+                    activated.Add("ClientSecretCredential");
+                }
+                else
+                {
+                    Console.WriteLine(
+                        "AzureAd:AllowedAuthMethods includes 'ClientSecret' but tenantId, "
+                            + "clientId or clientSecret is missing/placeholder; skipping ClientSecretCredential."
+                    );
+                }
+            }
+            else
+            {
+                Console.WriteLine(
+                    $"Unknown auth method '{method}' in AzureAd:AllowedAuthMethods; "
+                        + "expected 'WorkloadIdentity' or 'ClientSecret'."
+                );
+            }
+        }
+
+        if (credentials.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "No usable Azure credential could be constructed from "
+                    + "AzureAd:AllowedAuthMethods. Configure at least one of "
+                    + "'WorkloadIdentity' or 'ClientSecret' (with the required values present)."
+            );
+        }
+
+        if (credentials.Count == 1)
+        {
+            Console.WriteLine($"Using {activated[0]} only");
+            return credentials[0];
+        }
+
+        Console.WriteLine("Using ChainedTokenCredential: " + string.Join(" -> ", activated));
+        return new ChainedTokenCredential([.. credentials]);
+    }
+
     public static IServiceCollection ConfigureDatabase(
         this IServiceCollection services,
         IConfiguration configuration

--- a/api/Database/Context/DesignTimeContextFactory.cs
+++ b/api/Database/Context/DesignTimeContextFactory.cs
@@ -1,4 +1,4 @@
-using Azure.Identity;
+using api.Configurations;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
@@ -38,7 +38,10 @@ namespace api.Database.Context
                     config.GetSection("KeyVault")["VaultUri"]
                     ?? throw new KeyNotFoundException("No key vault in config");
 
-                var keyVault = new SecretClient(new Uri(keyVaultUri), new DefaultAzureCredential());
+                var keyVault = new SecretClient(
+                    new Uri(keyVaultUri),
+                    CustomServiceConfigurations.CreateCredential(config)
+                );
 
                 connectionString = keyVault
                     .GetSecret("Database--postgresConnectionString")

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -5,7 +5,6 @@ using api.Configurations;
 using api.Database.Context;
 using api.MQTT;
 using api.Services;
-using Azure.Identity;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
@@ -23,7 +22,10 @@ if (builder.Configuration.GetSection("KeyVault").GetValue<bool>("UseKeyVault"))
     string? vaultUri = builder.Configuration.GetSection("KeyVault")["VaultUri"];
     if (!string.IsNullOrEmpty(vaultUri))
     {
-        builder.Configuration.AddAzureKeyVault(new Uri(vaultUri), new DefaultAzureCredential());
+        builder.Configuration.AddAzureKeyVault(
+            new Uri(vaultUri),
+            CustomServiceConfigurations.CreateCredential(builder.Configuration)
+        );
     }
     else
     {

--- a/api/appsettings.Local.json
+++ b/api/appsettings.Local.json
@@ -2,7 +2,8 @@
   "AppName": "SaraBackendLocal",
   "AzureAd": {
     "ClientId": "dd7e115a-037e-4846-99c4-07561158a9cd",
-    "ClientSecret": "Fill in ASP.NET Secret Manager"
+    "ClientSecret": "Fill in ASP.NET Secret Manager",
+    "AllowedAuthMethods": [ "ClientSecret" ]
   },
   "EndpointConfig": {
     "DefaultScheme": "http",

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -2,7 +2,8 @@
   "AppName": "sara-backend",
   "AzureAd": {
     "TenantId": "3aa4a235-b6e2-48d5-9195-7fcf05b459b0",
-    "Instance": "https://login.microsoftonline.com"
+    "Instance": "https://login.microsoftonline.com",
+    "AllowedAuthMethods": [ "ClientSecret", "WorkloadIdentity" ]
   },
   "Logging": {
     "LogLevel": {

--- a/workflow-notifier/.env.example
+++ b/workflow-notifier/.env.example
@@ -1,5 +1,11 @@
 SARA_SERVER_URL="http://localhost:8100/api"
 TENANT_ID=
 NOTIFIER_CLIENT_ID=
-NOTIFIER_CLIENT_SECRET=
 SARA_APP_REG_SCOPE=
+# Ordered, comma-separated list of credential types to try when acquiring an
+# Azure AD access token. Allowed values (case-insensitive): WorkloadIdentity,
+# ClientSecret. In cloud (AKS with Azure Workload Identity) use only
+# "WorkloadIdentity"; locally include "ClientSecret" so NOTIFIER_CLIENT_SECRET
+# is used.
+ALLOWED_AUTH_METHODS=WorkloadIdentity,ClientSecret
+NOTIFIER_CLIENT_SECRET=

--- a/workflow-notifier/pyproject.toml
+++ b/workflow-notifier/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "python-dotenv",
     "typer~=0.14",
     "requests~=2.32",
-    "msal~=1.31",
+    "azure-identity~=1.19",
     "pydantic",
     "pydantic-settings",
     "opentelemetry-api",

--- a/workflow-notifier/src/workflow_notifier/config/settings.py
+++ b/workflow-notifier/src/workflow_notifier/config/settings.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from dotenv import load_dotenv
 from pydantic import Field
 from pydantic_settings import BaseSettings
@@ -9,8 +11,21 @@ class Settings(BaseSettings):
     SARA_SERVER_URL: str
     TENANT_ID: str
     NOTIFIER_CLIENT_ID: str
-    NOTIFIER_CLIENT_SECRET: str
     SARA_APP_REG_SCOPE: str
+
+    # Optional client secret for local development. In cloud (AKS with Azure
+    # Workload Identity) this is not provided and the federated token file is
+    # used instead. Include "ClientSecret" in ALLOWED_AUTH_METHODS to enable
+    # the ClientSecretCredential path.
+    NOTIFIER_CLIENT_SECRET: Optional[str] = Field(default=None)
+
+    # Ordered list of credential types that may be used to acquire an Azure
+    # AD access token. Allowed entries (case-insensitive): "WorkloadIdentity",
+    # "ClientSecret". When more than one method is configured, the order
+    # determines the order inside the resulting ChainedTokenCredential.
+    # When provided via environment variables, supply a comma-separated
+    # value (e.g. ALLOWED_AUTH_METHODS=WorkloadIdentity,ClientSecret).
+    ALLOWED_AUTH_METHODS: list[str] = Field(default_factory=lambda: ["WorkloadIdentity"])
 
     OTEL_SERVICE_NAME: str = Field(default="workflow-notifier")
     OTEL_EXPORTER_OTLP_ENDPOINT: str = Field(default="http://localhost:4317")

--- a/workflow-notifier/src/workflow_notifier/notifier.py
+++ b/workflow-notifier/src/workflow_notifier/notifier.py
@@ -1,13 +1,24 @@
 import logging
+import os
+from functools import lru_cache
 
 import requests
 import typer
-from msal import ConfidentialClientApplication
+from azure.core.credentials import TokenCredential
+from azure.identity import (
+    ChainedTokenCredential,
+    ClientSecretCredential,
+    WorkloadIdentityCredential,
+)
 from opentelemetry import metrics
 
 from workflow_notifier.config.settings import settings
 
 logger = logging.getLogger(__name__)
+
+# Default path where the azure-workload-identity mutating webhook projects the
+# service-account token in the pod.
+_DEFAULT_FEDERATED_TOKEN_FILE = "/var/run/secrets/azure/tokens/azure-identity-token"
 
 meter = metrics.get_meter("workflow-notifier")
 workflow_counter = meter.create_counter(
@@ -18,32 +29,106 @@ workflow_counter = meter.create_counter(
 app = typer.Typer()
 
 
+@lru_cache(maxsize=1)
+def _get_credential() -> TokenCredential:
+    """
+    Build a TokenCredential.
+
+    The set of credential types to try is configured via
+    ``settings.ALLOWED_AUTH_METHODS``, an ordered list whose entries may be
+    ``"WorkloadIdentity"`` and/or ``"ClientSecret"`` (case-insensitive). When
+    more than one method is configured, the order determines the order inside
+    the resulting ``ChainedTokenCredential``.
+
+    In cloud (AKS with Azure Workload Identity), the standard ``AZURE_CLIENT_ID``,
+    ``AZURE_TENANT_ID``, ``AZURE_FEDERATED_TOKEN_FILE`` and ``AZURE_AUTHORITY_HOST``
+    environment variables are injected by the azure-workload-identity mutating
+    webhook, and ``WorkloadIdentityCredential`` exchanges the projected service
+    account token for an Entra ID access token.
+
+    For local development, include ``"ClientSecret"`` in
+    ``ALLOWED_AUTH_METHODS`` and provide ``NOTIFIER_CLIENT_SECRET``.
+    """
+    token_file_path = os.environ.get(
+        "AZURE_FEDERATED_TOKEN_FILE", _DEFAULT_FEDERATED_TOKEN_FILE
+    )
+    client_secret = settings.NOTIFIER_CLIENT_SECRET
+
+    credentials: list[TokenCredential] = []
+    activated: list[str] = []
+
+    allowed_methods = settings.ALLOWED_AUTH_METHODS or ["WorkloadIdentity"]
+
+    for method in allowed_methods:
+        normalized = method.strip().lower()
+        if normalized == "workloadidentity":
+            if os.path.exists(token_file_path):
+                credentials.append(
+                    WorkloadIdentityCredential(
+                        tenant_id=settings.TENANT_ID,
+                        client_id=settings.NOTIFIER_CLIENT_ID,
+                        token_file_path=token_file_path,
+                    )
+                )
+                activated.append("WorkloadIdentityCredential")
+            else:
+                logger.warning(
+                    "ALLOWED_AUTH_METHODS includes 'WorkloadIdentity' but no federated "
+                    f"token file found at '{token_file_path}'; skipping "
+                    "WorkloadIdentityCredential."
+                )
+        elif normalized == "clientsecret":
+            if client_secret and not client_secret.lower().startswith("fill in"):
+                credentials.append(
+                    ClientSecretCredential(
+                        tenant_id=settings.TENANT_ID,
+                        client_id=settings.NOTIFIER_CLIENT_ID,
+                        client_secret=client_secret,
+                    )
+                )
+                activated.append("ClientSecretCredential")
+            else:
+                logger.warning(
+                    "ALLOWED_AUTH_METHODS includes 'ClientSecret' but "
+                    "NOTIFIER_CLIENT_SECRET is missing/placeholder; skipping "
+                    "ClientSecretCredential."
+                )
+        else:
+            logger.warning(
+                f"Unknown auth method '{method}' in ALLOWED_AUTH_METHODS; "
+                "expected 'WorkloadIdentity' or 'ClientSecret'."
+            )
+
+    if not credentials:
+        raise RuntimeError(
+            "No usable Azure credential could be constructed from "
+            "ALLOWED_AUTH_METHODS. Configure at least one of 'WorkloadIdentity' "
+            "(with a federated token file present) or 'ClientSecret' (with "
+            "NOTIFIER_CLIENT_SECRET set)."
+        )
+
+    if len(credentials) == 1:
+        logger.info(f"Using {activated[0]} only")
+        return credentials[0]
+
+    logger.info(
+        "Using ChainedTokenCredential: " + " -> ".join(activated)
+    )
+    return ChainedTokenCredential(*credentials)
+
+
+
 def get_access_token() -> str:
     """
-    Acquire an access token using MSAL.
+    Acquire an access token for the SARA API using azure-identity.
     """
-    client_app = ConfidentialClientApplication(
-        client_id=settings.NOTIFIER_CLIENT_ID,
-        client_credential=settings.NOTIFIER_CLIENT_SECRET,
-        authority=settings.authority,
-    )
-    result = client_app.acquire_token_for_client(scopes=settings.scopes)
-
-    if result is None:
-        logger.error("Error acquiring token: MSAL returned None.")
+    credential = _get_credential()
+    try:
+        token = credential.get_token(*settings.scopes)
+    except Exception as e:
+        logger.error(f"Error acquiring token: {e}")
         raise typer.Exit(1)
-
-    if isinstance(result, dict) and "access_token" in result:
-        return result["access_token"]
-
-    error_message = (
-        f"Error acquiring token: {result.get('error', 'Unknown')} - "
-        f"{result.get('error_description', 'No description provided')}"
-        if isinstance(result, dict)
-        else "Error acquiring token: Unexpected result type."
-    )
-    logger.error(error_message)
-    raise typer.Exit(1)
+    return token.token
 
 
 def send_authenticated_put_request(url: str, payload: dict) -> None:

--- a/workflow-notifier/uv.lock
+++ b/workflow-notifier/uv.lock
@@ -25,6 +25,35 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
+]
+
+[[package]]
+name = "azure-identity"
+version = "1.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/9a/417b3a533e01953a7c618884df2cb05a71e7b68bdbce4fbdb62349d2a2e8/azure_identity-1.25.3-py3-none-any.whl", hash = "sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c", size = 192138, upload-time = "2026-03-13T01:12:22.951Z" },
+]
+
+[[package]]
 name = "black"
 version = "26.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -491,6 +520,18 @@ wheels = [
 ]
 
 [[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
@@ -938,7 +979,7 @@ wheels = [
 name = "workflow-notifier"
 source = { editable = "." }
 dependencies = [
-    { name = "msal" },
+    { name = "azure-identity" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-sdk" },
@@ -960,10 +1001,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = "~=1.19" },
     { name = "black", marker = "extra == 'dev'" },
     { name = "flask", marker = "extra == 'dev'" },
     { name = "isort", marker = "extra == 'dev'" },
-    { name = "msal", specifier = "~=1.31" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },


### PR DESCRIPTION
## Summary
- Adds a `CreateCredential` helper in the .NET API that returns a `WorkloadIdentityCredential` by default, with an opt-in `ChainedTokenCredential` → `ClientSecretCredential` fallback gated by `AzureAd:AllowUsingClientSecret` (mirroring the [Flotilla pattern](https://github.com/equinor/flotilla/blob/main/backend/api/Configurations/CustomServiceConfigurations.cs)).
- Wires Key Vault loading (`Program.cs` and the EF design-time `SecretClient`) through the new helper.
- Migrates the Python `workflow-notifier` from `msal.ConfidentialClientApplication` to `azure-identity` with the same workload-identity / client-secret-fallback pattern, gated by `ALLOW_USING_CLIENT_SECRET`.

This is the first step of [#347](https://github.com/equinor/sara/issues/347). It is intentionally narrow:
- `EmailService` is **left on `ClientSecretCredential`** for now. The pod's federated token is currently bound to the UAMI (`saradev-mi` etc.), not the app registration, so switching `EmailService` would break email until the infra repointing lands. KV access continues to work because the UAMI has `secrets get/list`.
- Postgres and Blob storage migrations to identity-based auth are deferred to follow-up PRs.

## Behavior
- **Cloud (today):** identical to before. `WorkloadIdentityCredential` is used to load Key Vault secrets — currently against the UAMI; will transparently work against the app registration once the `analytics-infrastructure` PR repoints `azure.workload.identity/client-id` on `robotics-analytics-sa`.
- **Local dev:** `appsettings.Local.json` sets `AzureAd:AllowUsingClientSecret: true`, so the existing `ClientSecretCredential` path keeps working.
- **CI / integration tests:** set `AzureAd__AllowUsingClientSecret=true` (or via env) to keep the existing `INTEGRATION_TEST_AZURE_CLIENT_SECRET` flow.

## Verification
- `dotnet build api/api.csproj` → 0 warnings, 0 errors.
- `uv sync --extra dev` resolves `azure-identity~=1.19`.
- All three `_get_credential()` branches in the notifier exercised manually (`WorkloadIdentityCredential` only, `ClientSecretCredential` only, `ChainedTokenCredential`).
- Existing `test_main.py` import path passes.

## Follow-up work (separate PRs)
1. **Infra (`equinor/analytics-infrastructure`):** add a federated identity credential on the **app registration** in Entra ID; switch the SA annotation `azure.workload.identity/client-id` in `overlays/{development,staging,production}/patches/id.yaml` from the UAMI to the app-reg client-id.
2. Migrate `EmailService` to `CreateCredential`.
3. Postgres → Entra ID auth (Npgsql `UsePeriodicPasswordProvider` with scope `https://ossrdbms-aad.database.windows.net/.default`, with a Key Vault connection-string fallback).
4. Blob storage → identity-based (`BlobServiceClient(Uri, TokenCredential)`).
5. Remove `AZURE_CLIENT_SECRET` from `base/sara.yaml`, KV cleanup, drop the unused UAMI Bicep.

Closes part of #347.