### PR TITLE
Allow null oilLevel and confidence in CLOEResult

### DIFF
--- a/api.Tests/Mocks/RecordingTimeseriesService.cs
+++ b/api.Tests/Mocks/RecordingTimeseriesService.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using api.Services;
+
+namespace Api.Test.Mocks;
+
+/// <summary>
+/// Test fake for <see cref="ITimeseriesService"/> that records every upload
+/// request for later inspection by tests. CO2 fetches return null.
+/// </summary>
+public class RecordingTimeseriesService : ITimeseriesService
+{
+    private readonly ConcurrentQueue<TriggerTimeseriesUploadRequest> _uploads = new();
+
+    public IReadOnlyCollection<TriggerTimeseriesUploadRequest> Uploads => _uploads.ToArray();
+
+    public Task TriggerTimeseriesUpload(TriggerTimeseriesUploadRequest uploadRequest)
+    {
+        _uploads.Enqueue(uploadRequest);
+        return Task.CompletedTask;
+    }
+
+    public Task<double?> FetchCO2ConcentrationFromTimeseries(FetchCO2MeasurementRequest fetchRequest)
+    {
+        return Task.FromResult<double?>(null);
+    }
+
+    public void Reset()
+    {
+        _uploads.Clear();
+    }
+}

--- a/api.Tests/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandlerTests.cs
+++ b/api.Tests/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandlerTests.cs
@@ -130,4 +130,59 @@ public class CLOEResultHandlerTests : IAsyncLifetime
         Assert.Null(published.Value);
         Assert.Null(published.Confidence);
     }
+
+    [Fact]
+    public async Task OnWorkflowCompleted_LowConfidenceResultWithNullFields_PublishesNullValueAndConfidence()
+    {
+        var record = await _db.NewInspectionRecord(inspectionId: "insp-123");
+        var analysis = await _db.NewAnalysis(inspectionRecords: [record]);
+        var run = await _db.NewAnalysisRun(analysis);
+        var workflow = await _db.NewWorkflow(run, workflowType: "cloe");
+        workflow.ResultJson = JsonSerializer.Serialize(
+            new { oilLevel = (float?)null, confidence = (float?)null }
+        );
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        using var scope = _factory.Services.CreateScope();
+        var handler = ResolveHandler(scope);
+
+        await handler.OnWorkflowCompleted(workflow);
+
+        var published = Assert.Single(_factory.MqttPublisher.AnalysisResultMessages);
+        Assert.Null(published.Value);
+        Assert.Null(published.Confidence);
+        Assert.Null(published.Warning);
+    }
+
+    [Fact]
+    public async Task OnWorkflowCompleted_ResultWithWarning_PublishesWarning()
+    {
+        const float oilLevel = 0.02f;
+        const float confidence = 0.80f;
+        const string warning = "Oil level is below 5 %";
+
+        var record = await _db.NewInspectionRecord(inspectionId: "insp-123");
+        var analysis = await _db.NewAnalysis(inspectionRecords: [record]);
+        var run = await _db.NewAnalysisRun(analysis);
+        var workflow = await _db.NewWorkflow(run, workflowType: "cloe");
+        workflow.ResultJson = JsonSerializer.Serialize(
+            new
+            {
+                oilLevel = oilLevel,
+                confidence = confidence,
+                warning = warning,
+            }
+        );
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        using var scope = _factory.Services.CreateScope();
+        var handler = ResolveHandler(scope);
+
+        await handler.OnWorkflowCompleted(workflow);
+
+        var published = Assert.Single(_factory.MqttPublisher.AnalysisResultMessages);
+        Assert.Equal(oilLevel.ToString("F2"), published.Value);
+        Assert.Equal(confidence * 100, published.Confidence);
+        Assert.Equal(warning, published.Warning);
+    }
 }

--- a/api.Tests/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandlerTests.cs
+++ b/api.Tests/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandlerTests.cs
@@ -75,6 +75,9 @@ public class CLOEResultHandlerTests : IAsyncLifetime
         var published = Assert.Single(_factory.MqttPublisher.AnalysisResultMessages);
         Assert.Equal(oilLevel.ToString("F2"), published.Value);
         Assert.Equal(confidence * 100, published.Confidence);
+
+        var upload = Assert.Single(_factory.TimeseriesService.Uploads);
+        Assert.Equal(oilLevel, upload.Value);
     }
 
     [Fact]
@@ -184,5 +187,45 @@ public class CLOEResultHandlerTests : IAsyncLifetime
         Assert.Equal(oilLevel.ToString("F2"), published.Value);
         Assert.Equal(confidence * 100, published.Confidence);
         Assert.Equal(warning, published.Warning);
+    }
+
+    [Fact]
+    public async Task OnWorkflowCompleted_NullOilLevel_DoesNotUploadTimeseries()
+    {
+        var record = await _db.NewInspectionRecord(inspectionId: "insp-123");
+        var analysis = await _db.NewAnalysis(inspectionRecords: [record]);
+        var run = await _db.NewAnalysisRun(analysis);
+        var workflow = await _db.NewWorkflow(run, workflowType: "cloe");
+        workflow.ResultJson = JsonSerializer.Serialize(
+            new { oilLevel = (float?)null, confidence = 0.9f }
+        );
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        using var scope = _factory.Services.CreateScope();
+        var handler = ResolveHandler(scope);
+
+        await handler.OnWorkflowCompleted(workflow);
+
+        Assert.Empty(_factory.TimeseriesService.Uploads);
+    }
+
+    [Fact]
+    public async Task OnWorkflowCompleted_NullConfidence_DoesNotUploadTimeseries()
+    {
+        var record = await _db.NewInspectionRecord(inspectionId: "insp-123");
+        var analysis = await _db.NewAnalysis(inspectionRecords: [record]);
+        var run = await _db.NewAnalysisRun(analysis);
+        var workflow = await _db.NewWorkflow(run, workflowType: "cloe");
+        workflow.ResultJson = JsonSerializer.Serialize(
+            new { oilLevel = 0.42f, confidence = (float?)null }
+        );
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        using var scope = _factory.Services.CreateScope();
+        var handler = ResolveHandler(scope);
+
+        await handler.OnWorkflowCompleted(workflow);
+
+        Assert.Empty(_factory.TimeseriesService.Uploads);
     }
 }

--- a/api.Tests/TestWebApplicationFactory.cs
+++ b/api.Tests/TestWebApplicationFactory.cs
@@ -34,6 +34,7 @@ public class TestWebApplicationFactory<TProgram>(string postgresConnectionString
     public RecordingMqttPublisher MqttPublisher { get; } = new();
     public RecordingHttpMessageHandler ArgoHttpHandler { get; } = new();
     public RecordingEmailService EmailService { get; } = new();
+    public RecordingTimeseriesService TimeseriesService { get; } = new();
 
     /// <summary>
     /// Returns the configured Argo trigger URL for the given workflow type.
@@ -71,6 +72,7 @@ public class TestWebApplicationFactory<TProgram>(string postgresConnectionString
             ReplaceMqttPublisher(services);
             ReplaceArgoHttpClient(services);
             ReplaceEmailService(services);
+            ReplaceTimeseriesService(services);
             ReplaceAuthentication(services);
             RegisterMqttEventHandler(services);
             RemoveHostedServices(services);
@@ -125,6 +127,16 @@ public class TestWebApplicationFactory<TProgram>(string postgresConnectionString
             services.Remove(descriptor);
         }
         services.AddSingleton<IEmailService>(EmailService);
+    }
+
+    private void ReplaceTimeseriesService(IServiceCollection services)
+    {
+        var existing = services.Where(d => d.ServiceType == typeof(ITimeseriesService)).ToList();
+        foreach (var descriptor in existing)
+        {
+            services.Remove(descriptor);
+        }
+        services.AddSingleton<ITimeseriesService>(TimeseriesService);
     }
 
     private static void RemoveHostedServices(IServiceCollection services)

--- a/api.Tests/appsettings.Test.json
+++ b/api.Tests/appsettings.Test.json
@@ -28,6 +28,7 @@
   "Frontend": {
     "Enabled": false
   },
+  "SARATimeseriesBaseUrl": "",
   "OpenTelemetry": {
     "Enabled": false
   },

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandler.cs
@@ -7,8 +7,8 @@ namespace api.Services.ResultHandlers.WorkflowResultHandlers;
 
 internal sealed class CLOEResult
 {
-    public float OilLevel { get; set; }
-    public float Confidence { get; set; }
+    public float? OilLevel { get; set; }
+    public float? Confidence { get; set; }
     public string? Warning { get; set; }
 }
 
@@ -58,9 +58,9 @@ public class CLOEResultHandler(
             AnalysisRunId = workflow.AnalysisRunId,
             AnalysisId = workflow.AnalysisRun.AnalysisId,
             AnalysisType = workflow.WorkflowType,
-            Value = result?.OilLevel.ToString("F2"),
+            Value = result?.OilLevel?.ToString("F2"),
             Unit = "fraction [oilLevel]",
-            Confidence = result is null ? null : result.Confidence * 100,
+            Confidence = result?.Confidence is { } c ? c * 100 : null,
             Warning = result?.Warning,
         };
 

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandler.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using api.Database.Context;
 using api.Database.Models;
 using api.MQTT;
@@ -15,6 +16,7 @@ internal sealed class CLOEResult
 public class CLOEResultHandler(
     SaraDbContext context,
     IMqttPublisherService mqttPublisherService,
+    ITimeseriesService timeseriesService,
     ILogger<CLOEResultHandler> logger
 ) : IWorkflowResultHandler
 {
@@ -72,5 +74,54 @@ public class CLOEResultHandler(
         }
 
         await mqttPublisherService.PublishSaraAnalysisResultAvailable(message);
+
+        await TryUploadTimeseries(workflow, inspectionRecord, result);
+    }
+
+    private async Task TryUploadTimeseries(
+        Workflow workflow,
+        InspectionRecord inspectionRecord,
+        CLOEResult? result
+    )
+    {
+        if (result?.OilLevel is not { } oilLevel || result.Confidence is not { } confidence)
+        {
+            logger.LogWarning(
+                "Skipping CLOE timeseries upload for workflow {WorkflowId}: oilLevel or confidence is null",
+                workflow.Id
+            );
+            return;
+        }
+
+        var uploadRequest = new TriggerTimeseriesUploadRequest
+        {
+            Name =
+                $"{inspectionRecord.InstallationCode}_{inspectionRecord.Tag}_{inspectionRecord.InspectionDescription}",
+            Facility = inspectionRecord.InstallationCode,
+            ExternalId = "",
+            Description = "CLOE-oil-level",
+            Unit = "percentage",
+            AssetId = inspectionRecord.InstallationCode,
+            Value = oilLevel,
+            Timestamp = inspectionRecord.Timestamp ?? DateTime.UtcNow,
+            Step = true,
+            Metadata = new Dictionary<string, string>
+            {
+                { "Confidence", confidence.ToString(CultureInfo.InvariantCulture) },
+            },
+        };
+
+        try
+        {
+            await timeseriesService.TriggerTimeseriesUpload(uploadRequest);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Failed to upload CLOE oil-level datapoint to Timeseries for workflow {WorkflowId}",
+                workflow.Id
+            );
+        }
     }
 }

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -82,8 +82,5 @@
     "Fencilla": {
       "Installations": {}
     }
-  },
-  "Thresholds": {
-    "CLOETimeseriesUploadConfidenceThreshold": 0.6
   }
 }


### PR DESCRIPTION
Loosens `CLOEResult.OilLevel` and `CLOEResult.Confidence` to `float?` so low-confidence cloe results (now emitting null) deserialize cleanly. The MQTT projection publishes null `Value`/`Confidence` in that case.

## Linked PRs
- equinor/sara-constant-level-oiler#63 — analyzer emits `result.json` with thresholds
- equinor/analytics-infrastructure#283 — Argo template + ConfigMap thresholds