### PR TITLE
Restore legacy CLOE percentage and thermal-reading timeseries upload

### DIFF
--- a/api.Tests/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandlerTests.cs
+++ b/api.Tests/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandlerTests.cs
@@ -73,11 +73,11 @@ public class CLOEResultHandlerTests : IAsyncLifetime
         await handler.OnWorkflowCompleted(workflow);
 
         var published = Assert.Single(_factory.MqttPublisher.AnalysisResultMessages);
-        Assert.Equal(oilLevel.ToString("F2"), published.Value);
+        Assert.Equal((oilLevel * 100).ToString("F2"), published.Value);
         Assert.Equal(confidence * 100, published.Confidence);
 
         var upload = Assert.Single(_factory.TimeseriesService.Uploads);
-        Assert.Equal(oilLevel, upload.Value);
+        Assert.Equal(oilLevel * 100, upload.Value);
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class CLOEResultHandlerTests : IAsyncLifetime
         await handler.OnWorkflowCompleted(workflow);
 
         var published = Assert.Single(_factory.MqttPublisher.AnalysisResultMessages);
-        Assert.Equal(oilLevel.ToString("F2"), published.Value);
+        Assert.Equal((oilLevel * 100).ToString("F2"), published.Value);
         Assert.Equal(confidence * 100, published.Confidence);
         Assert.Equal(warning, published.Warning);
     }

--- a/api.Tests/Services/ResultHandlers/WorkflowResultHandlers/ThermalReadingResultHandlerTests.cs
+++ b/api.Tests/Services/ResultHandlers/WorkflowResultHandlers/ThermalReadingResultHandlerTests.cs
@@ -138,4 +138,40 @@ public class ThermalReadingResultHandlerTests : IAsyncLifetime
         Assert.Null(published.Value);
         Assert.Null(published.Confidence);
     }
+
+    [Fact]
+    public async Task OnWorkflowCompleted_ValidResult_UploadsTimeseries()
+    {
+        var record = await _db.NewInspectionRecord(inspectionId: "insp-123");
+        var analysis = await _db.NewAnalysis(inspectionRecords: [record]);
+        var run = await _db.NewAnalysisRun(analysis);
+        var workflow = await _db.NewWorkflow(run, workflowType: "thermal-reading");
+        const float temperature = 23.5f;
+        workflow.ResultJson = JsonSerializer.Serialize(new { temperature = temperature });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        using var scope = _factory.Services.CreateScope();
+        var handler = ResolveHandler(scope);
+
+        await handler.OnWorkflowCompleted(workflow);
+
+        var upload = Assert.Single(_factory.TimeseriesService.Uploads);
+        Assert.Equal(temperature, upload.Value);
+    }
+
+    [Fact]
+    public async Task OnWorkflowCompleted_NullResultJson_DoesNotUploadTimeseries()
+    {
+        var record = await _db.NewInspectionRecord(inspectionId: "insp-123");
+        var analysis = await _db.NewAnalysis(inspectionRecords: [record]);
+        var run = await _db.NewAnalysisRun(analysis);
+        var workflow = await _db.NewWorkflow(run, workflowType: "thermal-reading");
+
+        using var scope = _factory.Services.CreateScope();
+        var handler = ResolveHandler(scope);
+
+        await handler.OnWorkflowCompleted(workflow);
+
+        Assert.Empty(_factory.TimeseriesService.Uploads);
+    }
 }

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandler.cs
@@ -60,8 +60,8 @@ public class CLOEResultHandler(
             AnalysisRunId = workflow.AnalysisRunId,
             AnalysisId = workflow.AnalysisRun.AnalysisId,
             AnalysisType = workflow.WorkflowType,
-            Value = result?.OilLevel?.ToString("F2"),
-            Unit = "fraction [oilLevel]",
+            Value = result?.OilLevel is { } oil ? (oil * 100).ToString("F2") : null,
+            Unit = "percentage",
             Confidence = result?.Confidence is { } c ? c * 100 : null,
             Warning = result?.Warning,
         };
@@ -102,7 +102,7 @@ public class CLOEResultHandler(
             Description = "CLOE-oil-level",
             Unit = "percentage",
             AssetId = inspectionRecord.InstallationCode,
-            Value = oilLevel,
+            Value = oilLevel * 100,
             Timestamp = inspectionRecord.Timestamp ?? DateTime.UtcNow,
             Step = true,
             Metadata = new Dictionary<string, string>

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/ThermalReadingResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/ThermalReadingResultHandler.cs
@@ -15,6 +15,7 @@ internal sealed class ThermalReadingResult
 public class ThermalReadingResultHandler(
     SaraDbContext context,
     IMqttPublisherService mqttPublisherService,
+    ITimeseriesService timeseriesService,
     ILogger<ThermalReadingResultHandler> logger
 ) : IWorkflowResultHandler
 {
@@ -75,5 +76,56 @@ public class ThermalReadingResultHandler(
         }
 
         await mqttPublisherService.PublishSaraAnalysisResultAvailable(message);
+
+        await TryUploadTimeseries(workflow, inspectionRecord, result);
+    }
+
+    private async Task TryUploadTimeseries(
+        Workflow workflow,
+        InspectionRecord inspectionRecord,
+        ThermalReadingResult? result
+    )
+    {
+        if (result is null)
+        {
+            logger.LogWarning(
+                "Skipping thermal-reading timeseries upload for workflow {WorkflowId}: result is null",
+                workflow.Id
+            );
+            return;
+        }
+
+        var uploadRequest = new TriggerTimeseriesUploadRequest
+        {
+            Name =
+                $"{inspectionRecord.InstallationCode}_{inspectionRecord.Tag}_{inspectionRecord.InspectionDescription?.Replace(" ", "-")}",
+            Facility = inspectionRecord.InstallationCode,
+            ExternalId = "",
+            Description = "ThermalReading",
+            Unit = "°C",
+            AssetId = inspectionRecord.InstallationCode,
+            Value = result.Temperature,
+            Timestamp = inspectionRecord.Timestamp ?? DateTime.UtcNow,
+            Step = true,
+            Metadata = new Dictionary<string, string>
+            {
+                { "tag_id", inspectionRecord.Tag ?? "" },
+                { "inspection_description", inspectionRecord.InspectionDescription ?? "" },
+                { "robot_name", inspectionRecord.RobotName ?? "" },
+            },
+        };
+
+        try
+        {
+            await timeseriesService.TriggerTimeseriesUpload(uploadRequest);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Failed to upload thermal-reading datapoint to Timeseries for workflow {WorkflowId}",
+                workflow.Id
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Multiply CLOE oil level by 100 and report `Unit = "percentage"` on both the MQTT result and the timeseries upload, so Flotilla (which renders `Value` with a `%` suffix on a 0-100 scale) shows e.g. `42%` instead of `0.42%`.
- Restore the thermal-reading timeseries upload that was lost in the workflow-handler refactor: `ThermalReadingResultHandler` now injects `ITimeseriesService` and uploads the temperature reading (°C) after publishing the MQTT result, mirroring the CLOE handler's `TryUploadTimeseries` pattern.

## Notes

- See equinor/sara-thermal-reading#114 — when sara-thermal-reading fails to write `temperature_output.txt`, SARA currently sees a missing JSON key and uploads `0.0` as a real reading. That should be fixed at the source before this lands in production.