### PR TITLE
Sanitize user input in AnalysisTriggerService and ThermalReferenceMetadataService log entries

### DIFF
--- a/api/Services/AnalysisTriggerService.cs
+++ b/api/Services/AnalysisTriggerService.cs
@@ -2,6 +2,7 @@ using api.Configurations;
 using api.Database.Context;
 using api.Database.Models;
 using api.MQTT;
+using api.Utilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -35,6 +36,23 @@ public class AnalysisTriggerService(
                 createdEvent.InspectionRecordId
             );
             return;
+        }
+
+        inspectionRecord.InspectionId = Sanitize.SanitizeUserInput(inspectionRecord.InspectionId);
+        if (createdEvent.AnalysisGroup is not null)
+        {
+            createdEvent.AnalysisGroup.AnalysisGroupId = Sanitize.SanitizeUserInput(
+                createdEvent.AnalysisGroup.AnalysisGroupId
+            );
+            createdEvent.AnalysisGroup.AnalysisGroupAnalyses = createdEvent
+                .AnalysisGroup.AnalysisGroupAnalyses.Select(Sanitize.SanitizeUserInput)
+                .ToList();
+        }
+        if (createdEvent.RequiredAnalysis is not null)
+        {
+            createdEvent.RequiredAnalysis = createdEvent
+                .RequiredAnalysis.Select(Sanitize.SanitizeUserInput)
+                .ToList();
         }
 
         var analysisNames = GetAnalysesToRun(createdEvent, inspectionRecord);
@@ -167,6 +185,7 @@ public class AnalysisTriggerService(
 
         if (existing is not null)
         {
+            existing.GroupId = Sanitize.SanitizeUserInput(existing.GroupId);
             return existing;
         }
 
@@ -396,6 +415,12 @@ public class AnalysisTriggerService(
         if (analysis is null)
         {
             throw new KeyNotFoundException($"Analysis with id {analysisId} not found");
+        }
+
+        analysis.Name = Sanitize.SanitizeUserInput(analysis.Name);
+        foreach (var record in analysis.InspectionRecords)
+        {
+            record.InspectionId = Sanitize.SanitizeUserInput(record.InspectionId);
         }
 
         if (!_options.Analyses.ContainsKey(analysis.Name))

--- a/api/Services/ThermalReferenceMetadataService.cs
+++ b/api/Services/ThermalReferenceMetadataService.cs
@@ -1,5 +1,6 @@
 using api.Database.Context;
 using api.Database.Models;
+using api.Utilities;
 using Microsoft.EntityFrameworkCore;
 
 namespace api.Services;
@@ -91,6 +92,10 @@ public class ThermalReferenceMetadataService(
         BlobStorageLocation referencePolygonLocation
     )
     {
+        input.InstallationCode = Sanitize.SanitizeUserInput(input.InstallationCode);
+        input.TagId = Sanitize.SanitizeUserInput(input.TagId);
+        input.InspectionDescription = Sanitize.SanitizeUserInput(input.InspectionDescription);
+
         await ThrowIfDuplicateExists(input, null);
 
         var thermalReferenceMetadata = new ThermalReferenceMetadata
@@ -114,6 +119,10 @@ public class ThermalReferenceMetadataService(
         BlobStorageLocation referencePolygonLocation
     )
     {
+        input.InstallationCode = Sanitize.SanitizeUserInput(input.InstallationCode);
+        input.TagId = Sanitize.SanitizeUserInput(input.TagId);
+        input.InspectionDescription = Sanitize.SanitizeUserInput(input.InspectionDescription);
+
         var thermalReferenceMetadata =
             await ReadById(id)
             ?? throw new KeyNotFoundException(


### PR DESCRIPTION
## Summary

Fixes 13 open CodeQL `cs/log-forging` (CWE-117) code-scanning alerts by re-applying the existing `Sanitize.SanitizeUserInput` helper at the public service entry points, mirroring the established pattern from commit ac46c14 (`fix(api): sanitize user input in PlantDataService log entries`).

## Why this is needed

The controllers and MQTT handlers already sanitize incoming user-controlled values, but CodeQL's `cs/log-forging` taint analysis does not follow the custom `Sanitize.SanitizeUserInput` helper across method/MQTT/DB boundaries. Re-applying the sanitizer at the service entry point keeps the data-flow local and recognized by the analysis, eliminating the alerts without changing observable behavior.

## Changes

### `api/Services/AnalysisTriggerService.cs` (10 alerts)
- `OnInspectionRecordCreated`: sanitize `inspectionRecord.InspectionId`, `createdEvent.AnalysisGroup.AnalysisGroupId`, `createdEvent.AnalysisGroup.AnalysisGroupAnalyses` items, and `createdEvent.RequiredAnalysis` items at the top of the method (right after the null check on `inspectionRecord`).
- `RerunAnalysis`: sanitize `analysis.Name` and each `record.InspectionId` after loading from the DB.
- `GetOrCreateAnalysisGroup`: re-sanitize `existing.GroupId` when an existing group is loaded from the DB, since CodeQL still treats stored strings as tainted across the round-trip.

### `api/Services/ThermalReferenceMetadataService.cs` (3 alerts)
- `CreateThermalReferenceMetadata` and `UpdateThermalReferenceMetadata`: sanitize `input.InstallationCode`, `input.TagId`, `input.InspectionDescription` at the top of each method (so the sanitized values are also what get persisted to the DB — matching the `PlantDataService.CreatePlantData` pattern).
- Added `using api.Utilities;`.

## False positives?

None of the 13 alerts are false positives in CodeQL's threat model — all tainted values originate from `[FromBody]` HTTP requests or MQTT messages. The fixes resolve them properly rather than dismissing.

## Verification

- `dotnet build api/api.csproj` succeeds with 0 warnings / 0 errors.
- No behavioral changes beyond stripping any `\r`/`\n` from the listed user-controlled strings (already done at the controller layer for most fields; this PR makes it visible to CodeQL and also defends in depth).

## Code-scanning alerts addressed

`ThermalReferenceMetadataService.cs`:
- https://github.com/equinor/sara/security/code-scanning/71
- https://github.com/equinor/sara/security/code-scanning/72
- https://github.com/equinor/sara/security/code-scanning/73

`AnalysisTriggerService.cs`:
- https://github.com/equinor/sara/security/code-scanning/74
- https://github.com/equinor/sara/security/code-scanning/75
- https://github.com/equinor/sara/security/code-scanning/76
- https://github.com/equinor/sara/security/code-scanning/77
- https://github.com/equinor/sara/security/code-scanning/78
- https://github.com/equinor/sara/security/code-scanning/79
- https://github.com/equinor/sara/security/code-scanning/80
- https://github.com/equinor/sara/security/code-scanning/81
- https://github.com/equinor/sara/security/code-scanning/82
- https://github.com/equinor/sara/security/code-scanning/83