### PR TITLE
Add frontend dependency update workflows

### DIFF
--- a/.github/workflows/frontend_dependency_security_fix.yml
+++ b/.github/workflows/frontend_dependency_security_fix.yml
@@ -1,0 +1,24 @@
+name: Frontend dependency security fix and create PR
+
+on:
+  push:
+    branches:
+      - main
+
+  schedule:
+    - cron: "5 6 * * 1-5" # At 06:05 on every day-of-week from Monday through Friday
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  audit-fix:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: equinor/armada/.github/workflows/pnpm_dependency_update_and_create_pr.yml@main
+    with:
+      working-directory: frontend
+      node-version: "24"
+      operation: audit-fix

--- a/.github/workflows/frontend_lint_and_test.yml
+++ b/.github/workflows/frontend_lint_and_test.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: "frontend"
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6

--- a/.github/workflows/monthly_frontend_dependency_update.yml
+++ b/.github/workflows/monthly_frontend_dependency_update.yml
@@ -1,0 +1,21 @@
+name: Monthly frontend dependency update and create PR
+
+on:
+  schedule:
+    - cron: "0 8 1 * *" # 08:00 UTC on the 1st of every month
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: equinor/armada/.github/workflows/pnpm_dependency_update_and_create_pr.yml@main
+    with:
+      working-directory: frontend
+      node-version: "24"
+      operation: update


### PR DESCRIPTION
Adds two scheduled workflows that consume the new reusable pnpm dependency-update workflow from equinor/armada#66:

- `monthly_frontend_dependency_update.yml` -- monthly `pnpm update` (1st of each month at 08:00 UTC)
- `frontend_dependency_security_fix.yml` -- weekday `pnpm audit --fix` (Mon-Fri at 06:05 UTC, plus on push to `main`)

Both open a PR with the resulting lockfile changes, labelled `automated-pr`. The min-release-age requirement is already enforced via the existing `minimumReleaseAge: 7200` (5 days) in `frontend/pnpm-workspace.yaml`.

Also bumps the existing `frontend_lint_and_test.yml` from Node 20 to Node 24 so CI matches the version used by the new workflows.

Depends on equinor/armada#66 being merged first.

Resolves: #359