### PR TITLE
Bump frontend Dockerfile to Node 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM node:22-slim AS frontend-build
+FROM node:24-slim AS frontend-build
 ENV CI=true
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app


### PR DESCRIPTION
Bumps the frontend build stage of the production Dockerfile from Node 22 to Node 24, aligning it with the CI lint/test workflow and the new dependency-update workflows that already use Node 24.

After #380 the repo was on three different Node versions (24 in CI and update workflows, 22 in the production image). This brings everything to Node 24.

- Lockfile engine constraints (`^20.19.0 || >=22.12.0`) are satisfied by Node 24, so no `pnpm install` regeneration is needed.
- TS / Vite versions in `frontend/` already support Node 24.