### PR TITLE
Prefer WorkloadIdentity over ClientSecret in dev

### DIFF
--- a/api/appsettings.Development.json
+++ b/api/appsettings.Development.json
@@ -2,7 +2,7 @@
   "AzureAd": {
     "ClientId": "dd7e115a-037e-4846-99c4-07561158a9cd",
     "ClientSecret": "",
-    "AllowedAuthMethods": [ "ClientSecret", "WorkloadIdentity" ]
+    "AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret" ]
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- Reorder `AzureAd:AllowedAuthMethods` in `appsettings.Development.json` from `["ClientSecret", "WorkloadIdentity"]` to `["WorkloadIdentity", "ClientSecret"]`.
- Cloud dev now exercises the federated `WorkloadIdentityCredential` first; `ClientSecretCredential` remains as fallback during cutover.
- No code changes; trivial rollback.

## Verification
- After deploy, `Runtime credential: using ChainedTokenCredential: WorkloadIdentityCredential -> ClientSecretCredential` should appear in dev pod logs.