### PR TITLE
Add Entra-ID auth path for Postgres

### DIFF
--- a/api/Configurations/CustomServiceConfigurations.cs
+++ b/api/Configurations/CustomServiceConfigurations.cs
@@ -7,6 +7,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi;
 using MQTTnet.Extensions.ManagedClient;
+using Npgsql;
 
 namespace api.Configurations;
 
@@ -287,6 +288,68 @@ public static class CustomServiceConfigurations
                     o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery)
                 )
             );
+
+            return services;
+        }
+
+        string? server = configuration["Database:Server"];
+        string? database = configuration["Database:Name"];
+        string? user = configuration["Database:User"];
+
+        bool useEntraAuth =
+            !string.IsNullOrWhiteSpace(server)
+            && !string.IsNullOrWhiteSpace(database)
+            && !string.IsNullOrWhiteSpace(user);
+
+        if (useEntraAuth)
+        {
+            // Build a single shared NpgsqlDataSource (connection pool) that fetches
+            // a fresh Entra-ID access token via the registered TokenCredential and
+            // uses it as the Postgres password. The PeriodicPasswordProvider keeps
+            // the token cached and refreshes it ahead of expiry.
+            services.AddSingleton<NpgsqlDataSource>(sp =>
+            {
+                var credential = sp.GetRequiredService<TokenCredential>();
+
+                string baseConnectionString =
+                    $"Host={server};Database={database};Username={user};SSL Mode=Require;Trust Server Certificate=true;";
+
+                var dataSourceBuilder = new NpgsqlDataSourceBuilder(baseConnectionString);
+                dataSourceBuilder.UsePeriodicPasswordProvider(
+                    async (_, ct) =>
+                    {
+                        var token = await credential
+                            .GetTokenAsync(
+                                new TokenRequestContext(
+                                    ["https://ossrdbms-aad.database.windows.net/.default"]
+                                ),
+                                ct
+                            )
+                            .ConfigureAwait(false);
+                        return token.Token;
+                    },
+                    successRefreshInterval: TimeSpan.FromMinutes(50),
+                    failureRefreshInterval: TimeSpan.FromSeconds(10)
+                );
+
+                return dataSourceBuilder.Build();
+            });
+
+            services.AddDbContext<SaraDbContext>(
+                (sp, options) =>
+                {
+                    var dataSource = sp.GetRequiredService<NpgsqlDataSource>();
+                    options.UseNpgsql(
+                        dataSource,
+                        o =>
+                        {
+                            o.UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery);
+                            o.EnableRetryOnFailure();
+                        }
+                    );
+                },
+                ServiceLifetime.Transient
+            );
         }
         else
         {
@@ -305,6 +368,7 @@ public static class CustomServiceConfigurations
                 ServiceLifetime.Transient
             );
         }
+
         return services;
     }
 

--- a/api/Database/Context/DesignTimeContextFactory.cs
+++ b/api/Database/Context/DesignTimeContextFactory.cs
@@ -1,7 +1,9 @@
 using api.Configurations;
+using Azure.Core;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Npgsql;
 
 namespace api.Database.Context
 {
@@ -30,6 +32,55 @@ namespace api.Database.Context
                 .AddEnvironmentVariables()
                 .Build();
 
+            string? server = config["Database:Server"];
+            string? database = config["Database:Name"];
+            string? user = config["Database:User"];
+
+            bool useEntraAuth =
+                !string.IsNullOrWhiteSpace(server)
+                && !string.IsNullOrWhiteSpace(database)
+                && !string.IsNullOrWhiteSpace(user);
+
+            var optionsBuilder = new DbContextOptionsBuilder<SaraDbContext>();
+
+            if (useEntraAuth)
+            {
+                TokenCredential credential = CustomServiceConfigurations.CreateRuntimeCredential(
+                    config
+                );
+
+                string baseConnectionString =
+                    $"Host={server};Database={database};Username={user};SSL Mode=Require;Trust Server Certificate=true;";
+
+                var dataSourceBuilder = new NpgsqlDataSourceBuilder(baseConnectionString);
+                dataSourceBuilder.UsePeriodicPasswordProvider(
+                    async (_, ct) =>
+                    {
+                        var token = await credential
+                            .GetTokenAsync(
+                                new TokenRequestContext(
+                                    ["https://ossrdbms-aad.database.windows.net/.default"]
+                                ),
+                                ct
+                            )
+                            .ConfigureAwait(false);
+                        return token.Token;
+                    },
+                    successRefreshInterval: TimeSpan.FromMinutes(50),
+                    failureRefreshInterval: TimeSpan.FromSeconds(10)
+                );
+
+                var dataSource = dataSourceBuilder.Build();
+
+                // Setting splitting behavior explicitly to avoid warning
+                optionsBuilder.UseNpgsql(
+                    dataSource,
+                    o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery)
+                );
+
+                return new SaraDbContext(optionsBuilder.Options);
+            }
+
             string? connectionString = config["Database:postgresConnectionString"];
 
             if (string.IsNullOrEmpty(connectionString))
@@ -47,8 +98,6 @@ namespace api.Database.Context
                     .GetSecret("Database--postgresConnectionString")
                     .Value.Value;
             }
-
-            var optionsBuilder = new DbContextOptionsBuilder<SaraDbContext>();
 
             // Setting splitting behavior explicitly to avoid warning
             optionsBuilder.UseNpgsql(

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -18,7 +18,10 @@
     "https://*.equinor.com/"
   ],
   "Database": {
-    "postgresConnectionString": ""
+    "postgresConnectionString": "",
+    "Server": "",
+    "Name": "",
+    "User": ""
   },
   "KeyVault": {
     "UseKeyVault": true


### PR DESCRIPTION
## Summary
- Adds an opt-in code path that authenticates to Postgres using a short-lived Entra-ID access token instead of a static password from Key Vault.
- Uses `NpgsqlDataSourceBuilder.UsePeriodicPasswordProvider` against the registered `TokenCredential` (scope `https://ossrdbms-aad.database.windows.net/.default`), with 50-min success / 10-sec failure refresh intervals.
- The shared `NpgsqlDataSource` is registered as a singleton (it owns the connection pool) and consumed by the transient `SaraDbContext`.
- `DesignTimeContextFactory` mirrors the same logic for `dotnet ef migrations`, using `CreateRuntimeCredential` directly (it cannot use DI).
- The existing connection-string path (`Database:postgresConnectionString`) is preserved as fallback for local dev, tests and the cutover.

## Activation
The new path activates only when **all three** of `Database:Server`, `Database:Name`, `Database:User` are configured (non-empty). Otherwise the existing connection-string path is used. This means the PR is safe to merge before any per-env config or server-side prep is done.

## Server-side prerequisites (per env, before populating the new keys)
1. Assign the sara app reg as **Microsoft Entra admin** of the Postgres flexible server.
2. Connect as Entra admin and run:
   ```sql
   CREATE ROLE "<sara-app-reg-display-name>" WITH LOGIN;
   GRANT CONNECT ON DATABASE <db> TO "<...>";
   GRANT USAGE ON SCHEMA public TO "<...>";
   GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO "<...>";
   GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO "<...>";
   ALTER DEFAULT PRIVILEGES IN SCHEMA public
     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "<...>";
   ALTER DEFAULT PRIVILEGES IN SCHEMA public
     GRANT USAGE, SELECT ON SEQUENCES TO "<...>";
   ```
3. Populate `Database:Server`, `Database:Name`, `Database:User` per env (env vars or per-env appsettings overrides). `User` is the role display name created in step 2.

## Rollout
Dev → staging → prod, restarting pods after each env's config is populated. Once prod is stable, `Database--postgresConnectionString` can be deleted from each Key Vault.

## Notes
- `NpgsqlDataSource` is registered as a singleton so the connection pool and password-provider cache are shared across all DbContext instances.
- `Trust Server Certificate=true` is included to match the typical PG flex setup; tighten if a custom CA bundle is provisioned.
- No changes to tests — `TestWebApplicationFactory` builds its own connection string against the test container.