### PR TITLE
Drop ClientSecret fallback now that workload identity is verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,39 @@ When running locally the endpoint is reachable at https://localhost:8100
 make run            # or: dotnet run --project api
 ```
 
+### Local authentication
+
+Cloud deployments authenticate via Azure Workload Identity (federated
+credentials on the sara app registration). Locally you have two options,
+selected by `ASPNETCORE_ENVIRONMENT`:
+
+- **`Local` (default for `make run`)** — uses `appsettings.Local.json`
+  with `AllowedAuthMethods: ["AzureCliBootstrap", "ClientSecret"]`.
+  Requires `az login` first; the developer's Azure CLI session is used
+  to bootstrap Key Vault access, and the app registration's client
+  secret is loaded from Key Vault for subsequent Azure calls.
+
+- **`Development` (mimics deployed dev)** — uses
+  `appsettings.Development.json` with
+  `AllowedAuthMethods: ["WorkloadIdentity", "ClientSecret"]`. Workload
+  Identity is unavailable outside AKS, so the chain falls through to
+  `ClientSecretCredential`. Provide the secret via an `api/.env` file
+  (gitignored):
+
+  ```
+  AzureAd__ClientSecret=<value of AzureAd--ClientSecret in saradev-kv>
+  ```
+
+  Then run:
+
+  ```bash
+  ASPNETCORE_ENVIRONMENT=Development dotnet run --project api
+  ```
+
+Use `Local` for normal day-to-day development. Use `Development` when
+you need behaviour identical to the deployed dev pod (real Postgres,
+real OpenTelemetry export, etc.).
+
 
 ## Test & format
 

--- a/api/Configurations/ConfigurationBuilderExtensions.cs
+++ b/api/Configurations/ConfigurationBuilderExtensions.cs
@@ -3,46 +3,6 @@ namespace api.Configurations
     public static class ConfigurationBuilderExtensions
     {
         /// <summary>
-        /// Creates the AZURE_CLIENT_ID, AZURE_TENANT_ID and LOCAL_DEVUSERID configuration values for the
-        /// <see href="https://docs.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet">Environment Credentials</see>
-        /// used by the application when dockerized.
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <returns></returns>
-        public static void AddAppSettingsEnvironmentVariables(this WebApplicationBuilder builder)
-        {
-            string? clientId = builder
-                .Configuration.GetSection("AzureAd")
-                .GetValue<string?>("ClientId");
-            if (clientId is not null)
-            {
-                Environment.SetEnvironmentVariable("AZURE_CLIENT_ID", clientId);
-                Console.WriteLine("'AZURE_CLIENT_ID' set to " + clientId);
-            }
-
-            string? tenantId = builder
-                .Configuration.GetSection("AzureAd")
-                .GetValue<string?>("TenantId");
-            if (tenantId is not null)
-            {
-                Environment.SetEnvironmentVariable("AZURE_TENANT_ID", tenantId);
-                Console.WriteLine("'AZURE_TENANT_ID' set to " + tenantId);
-            }
-
-            if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Local")
-            {
-                string? userId = builder
-                    .Configuration.GetSection("Local")
-                    .GetValue<string?>("DevUserId");
-                if (tenantId is not null)
-                {
-                    Environment.SetEnvironmentVariable("LOCAL_DEVUSERID", userId);
-                    Console.WriteLine("'LOCAL_DEVUSERID' set to " + userId);
-                }
-            }
-        }
-
-        /// <summary>
         /// Creates if don't already exist/sets all the configuration variables present on the .env file for the
         /// <see href="https://docs.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet">Environment Credentials</see>
         /// used by the application when dockerized.

--- a/api/Configurations/CustomServiceConfigurations.cs
+++ b/api/Configurations/CustomServiceConfigurations.cs
@@ -54,6 +54,14 @@ public static class CustomServiceConfigurations
         if (string.IsNullOrWhiteSpace(clientSecret))
             clientSecret = null;
 
+        // Fallback to the standard AZURE_* environment variables (read here via
+        // IConfiguration's environment-variable provider) when the corresponding
+        // AzureAd:* keys are not set in any config source. This matches the
+        // convention used by the Azure SDK credentials and keeps env-only
+        // configuration (e.g. cloud pods that only set AZURE_TENANT_ID /
+        // AZURE_CLIENT_ID via the deployment manifest, or local shells / CI
+        // jobs that only export AZURE_CLIENT_SECRET) working without requiring
+        // a parallel AzureAd:* entry in appsettings.
         tenantId ??= config["AZURE_TENANT_ID"];
         clientId ??= config["AZURE_CLIENT_ID"];
         clientSecret ??= config["AZURE_CLIENT_SECRET"];
@@ -175,6 +183,9 @@ public static class CustomServiceConfigurations
         if (string.IsNullOrWhiteSpace(clientSecret))
             clientSecret = null;
 
+        // See CreateCredential above for rationale: same fallback to the
+        // standard AZURE_* environment variables when the AzureAd:* keys are
+        // not populated in any other config source.
         tenantId ??= config["AZURE_TENANT_ID"];
         clientId ??= config["AZURE_CLIENT_ID"];
         clientSecret ??= config["AZURE_CLIENT_SECRET"];

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -19,7 +19,6 @@ var builder = WebApplication.CreateBuilder(args);
 
 Console.WriteLine($"\nENVIRONMENT IS SET TO '{builder.Environment.EnvironmentName}'\n");
 
-builder.AddAppSettingsEnvironmentVariables();
 builder.AddDotEnvironmentVariables(Path.Combine(Directory.GetCurrentDirectory(), ".env"));
 
 if (builder.Configuration.GetSection("KeyVault").GetValue<bool>("UseKeyVault"))

--- a/api/appsettings.Production.json
+++ b/api/appsettings.Production.json
@@ -1,8 +1,7 @@
 {
   "AzureAd": {
     "ClientId": "7d167947-b236-47ab-baa0-3d3575334237",
-    "ClientSecret": "Fill in ASP.NET Secret Manager",
-    "AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret" ]
+    "AllowedAuthMethods": [ "WorkloadIdentity" ]
   },
   "Logging": {
     "LogLevel": {

--- a/api/appsettings.Staging.json
+++ b/api/appsettings.Staging.json
@@ -1,8 +1,7 @@
 {
   "AzureAd": {
     "ClientId": "47a40d36-25a0-434c-8de2-94f703fb57f4",
-    "ClientSecret": "Fill in ASP.NET Secret Manager",
-    "AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret" ]
+    "AllowedAuthMethods": [ "WorkloadIdentity" ]
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- Sets `AzureAd:AllowedAuthMethods` to `["WorkloadIdentity"]` in Development, Staging and Production. ClientSecret is no longer in the credential chain in cloud.
- Removes `AzureAd:ClientSecret` placeholders from those three appsettings files.
- Removes the `AddAppSettingsEnvironmentVariables` shim and its caller in `Program.cs`. The shim copied `AzureAd:ClientId` / `TenantId` from config into the `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` env vars (originally to feed `DefaultAzureCredential.EnvironmentCredential`). It is no longer needed: we construct `WorkloadIdentityCredential` explicitly with these values from config, and the workload-identity webhook injects the same env vars in cloud anyway. The `LOCAL_DEVUSERID` env var that the shim also set was not read anywhere.

## Rollback safety
The `ClientSecret` branch in `CustomServiceConfigurations.CreateCredential` and `CreateRuntimeCredential` is intentionally left in place. If WI ever needs to be temporarily disabled, the rollback is a single config change (re-add `"ClientSecret"` to `AllowedAuthMethods` and ensure the secret is mounted) — no code revert required.

## Coordination
This PR must be deployed **before** the corresponding analytics-infrastructure cleanup PR that removes `AZURE_CLIENT_SECRET` from the sara pod env and the `AzureAd--ClientSecret` entry from the SecretProviderClass. Otherwise pods would boot expecting a secret that is no longer mounted.

## Verification
- `dotnet build` clean (api + api.test).
- After deploy, dev/staging/prod pod logs should show `Runtime credential: using WorkloadIdentityCredential` (no longer the `ChainedTokenCredential: WI -> CS` line).