### PR TITLE
Use OIDC federated credentials for migration workflows

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -16,14 +16,17 @@ on:
 jobs:
   run_migrations:
     name: Update database in Staging
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
     uses: equinor/armada/.github/workflows/run_dotnet_migrations.yml@main
     with:
       environment: Staging
       checkout_ref: ${{ github.event.release.tag_name }}
       working_directory: api
-    secrets:
-      client_id: ${{ secrets.CLIENTID }}
-      client_secret: ${{ secrets.CLIENTSECRET }}
+      azure_client_id: ${{ secrets.CLIENTID }}
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
   build-and-push-latest-release-images-to-ghcr:
     name: Build and push latest release images to github container registry

--- a/.github/workflows/promote_to_production.yaml
+++ b/.github/workflows/promote_to_production.yaml
@@ -39,14 +39,17 @@ jobs:
   run_migrations:
     name: Update database in Production
     needs: get_staging_version
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
     uses: equinor/armada/.github/workflows/run_dotnet_migrations.yml@main
     with:
       environment: Production
       checkout_ref: ${{ needs.get_staging_version.outputs.versionTag }}
       working_directory: api
-    secrets:
-      client_id: ${{ secrets.CLIENTID }}
-      client_secret: ${{ secrets.CLIENTSECRET }}
+      azure_client_id: ${{ secrets.CLIENTID }}
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
   deploy:
     name: Update deployment in Production

--- a/.github/workflows/run_development_migrations.yml
+++ b/.github/workflows/run_development_migrations.yml
@@ -14,9 +14,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      id-token: write
     with:
       environment: Development
       working_directory: api
-    secrets:
-      client_id: ${{ secrets.CLIENTID }}
-      client_secret: ${{ secrets.CLIENTSECRET }}
+      azure_client_id: ${{ secrets.CLIENTID }}
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
## Summary
- Update `deploy_to_staging.yml`, `promote_to_production.yaml` and `run_development_migrations.yml` to call the updated armada `run_dotnet_migrations.yml` reusable workflow with the new OIDC inputs.
- Pass `azure_client_id: \${{ secrets.CLIENTID }}` and `azure_subscription_id: \${{ vars.AZURE_SUBSCRIPTION_ID }}`; drop the `client_id`/`client_secret` secrets block.
- Grant `id-token: write` on each calling job.

## Depends on
- equinor/armada#67 — must be merged before this PR is merged (the reusable workflow is referenced as `@main`).

## Prerequisites (already done)
- GitHub Actions federated credentials created on `sara-dev`, `sara-staging` and `sara-prod` app registrations with subjects `repo:equinor/sara:environment:Development|Staging|Production`.
- Repo-level GitHub variable `AZURE_SUBSCRIPTION_ID` is set.

## Rollout
1. Merge after the armada PR is in.
2. Verify by manually dispatching `Run database migrations (Development)`.
3. Staging is verified by the next natural release.
4. Production is verified by manually dispatching `Promote to Production`.

## Follow-ups (separate PRs)
- Drop `CLIENTSECRET` from the Staging/Production GitHub Environments (kept on Development for local `dotnet ef` flows).
- Re-remove `ClientSecret` from `appsettings.{Staging,Production}.json` `AzureAd:AllowedAuthMethods`.
- Resume the `AZURE_CLIENT_SECRET` / `AzureAd--ClientSecret` cleanup in analytics-infrastructure (PR B1).

Refs equinor/sara#347.