### PR TITLE
Drop azure_client_id from migration workflow callers

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -25,7 +25,6 @@ jobs:
       environment: Staging
       checkout_ref: ${{ github.event.release.tag_name }}
       working_directory: api
-      azure_client_id: ${{ secrets.CLIENTID }}
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
   build-and-push-latest-release-images-to-ghcr:

--- a/.github/workflows/promote_to_production.yaml
+++ b/.github/workflows/promote_to_production.yaml
@@ -48,7 +48,6 @@ jobs:
       environment: Production
       checkout_ref: ${{ needs.get_staging_version.outputs.versionTag }}
       working_directory: api
-      azure_client_id: ${{ secrets.CLIENTID }}
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
   deploy:

--- a/.github/workflows/run_development_migrations.yml
+++ b/.github/workflows/run_development_migrations.yml
@@ -18,5 +18,4 @@ jobs:
     with:
       environment: Development
       working_directory: api
-      azure_client_id: ${{ secrets.CLIENTID }}
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
## Summary
Remove \`azure_client_id\` from the 3 migration workflow caller blocks. The reusable workflow now reads \`vars.CLIENTID\` directly from its env-scoped job.

## Why
The previous iteration placed \`secrets.CLIENTID\` in \`with:\`, which is rejected by GitHub's expression validator because \`secrets\` is not in the list of contexts available to \`jobs.<job_id>.with.<with_id>\`. Switching to \`vars.CLIENTID\` in \`with:\` does not work either when CLIENTID is environment-scoped, because the caller job has no \`environment:\` set and therefore env-scoped vars do not resolve.

Reading \`vars.CLIENTID\` inside the reusable workflow's env-scoped job is the reliable pattern, so the parameter is dropped from the caller side entirely.

## Depends on
- equinor/armada — companion PR makes the reusable read \`vars.CLIENTID\` directly. Must be merged first.

## Prerequisites
\`CLIENTID\` must be defined as an **environment variable** (not a secret) on each GitHub Environment in this repo:
- Development → \`dd7e115a-037e-4846-99c4-07561158a9cd\`
- Staging → \`47a40d36-25a0-434c-8de2-94f703fb57f4\`
- Production → \`7d167947-b236-47ab-baa0-3d3575334237\`

## Changes
3 files changed in \`.github/workflows/\`:
- \`deploy_to_staging.yml\`
- \`promote_to_production.yaml\`
- \`run_development_migrations.yml\`

Each: drop the \`secrets:\` block. \`azure_subscription_id\` stays in \`with:\` (uses \`vars.AZURE_SUBSCRIPTION_ID\`, a repo-level variable).