### PR TITLE
Allow AzureCliBootstrap fallback in CI migration jobs

### DIFF
--- a/api/appsettings.Development.json
+++ b/api/appsettings.Development.json
@@ -2,7 +2,7 @@
   "AzureAd": {
     "ClientId": "dd7e115a-037e-4846-99c4-07561158a9cd",
     "ClientSecret": "",
-    "AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret" ]
+    "AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret", "AzureCliBootstrap" ]
   },
   "Logging": {
     "LogLevel": {

--- a/api/appsettings.Production.json
+++ b/api/appsettings.Production.json
@@ -1,7 +1,7 @@
 {
   "AzureAd": {
     "ClientId": "7d167947-b236-47ab-baa0-3d3575334237",
-    "AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret" ]
+    "AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret", "AzureCliBootstrap" ]
   },
   "Logging": {
     "LogLevel": {

--- a/api/appsettings.Staging.json
+++ b/api/appsettings.Staging.json
@@ -1,7 +1,7 @@
 {
   "AzureAd": {
     "ClientId": "47a40d36-25a0-434c-8de2-94f703fb57f4",
-    "AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret" ]
+    "AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret", "AzureCliBootstrap" ]
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
Add `"AzureCliBootstrap"` to `AzureAd:AllowedAuthMethods` in Development, Staging, and Production. The existing `CustomServiceConfigurations.CreateCredential` already handles this method (lines 101–109) by appending `AzureCliCredential` to the credential chain — no application code changes needed.

## Why
Sara's CI migration job (`Run database migrations`) fails when relying on `WorkloadIdentityCredential` alone:

- `WorkloadIdentityCredential` requires `AZURE_FEDERATED_TOKEN_FILE` on disk (the AKS workload-identity contract). On a GitHub-hosted runner there is no such file.
- `azure/login@v2.3.0` (used by the armada reusable migration workflow) populates the `az` CLI cache at `~/.azure/`, but does not write a federated token file.
- The result was `CredentialUnavailableException: workload options are not fully configured` during `dotnet ef database update` → "All database authentication methods failed".

## Resulting credential chain
`CreateCredential` will produce a `ChainedTokenCredential`:

1. `WorkloadIdentityCredential` — succeeds in AKS pods (token file projected by kubelet); throws `CredentialUnavailableException` on a GitHub runner (no file).
2. `ClientSecretCredential` — succeeds for local devs with a populated `AzureAd:ClientSecret`; skipped on CI (no secret).
3. `AzureCliCredential` (new) — succeeds on CI after `azure/login` populates `~/.azure/`; effectively unreachable in AKS where (1) always wins.

`ChainedTokenCredential` falls through only on `CredentialUnavailableException`, so non-credential errors (e.g. RBAC denied) still surface immediately rather than being masked by a fallback.

## Why this is safe in production appsettings
`CreateRuntimeCredential` (used by the runtime PostgreSQL `AppRegIdentity` path) explicitly **skips** `AzureCliBootstrap` (`CustomServiceConfigurations.cs:170-173`), so this method only participates in the bootstrap chain used for Key Vault / general Azure access. In AKS pods that bootstrap chain is satisfied by `WorkloadIdentityCredential` first, and the `az` CLI is not installed in the runtime container anyway, so `AzureCliCredential` is inert there.

## Related
- equinor/armada#70 — companion comment-only PR documenting the same on the workflow side.