### PR TITLE
Add rain gate

### DIFF
--- a/api.Tests/Services/AnalysisTriggerServiceTests.cs
+++ b/api.Tests/Services/AnalysisTriggerServiceTests.cs
@@ -233,4 +233,43 @@ public class AnalysisTriggerServiceTests : IAsyncLifetime
         var request = Assert.Single(_factory.ArgoHttpHandler.Requests);
         Assert.Equal(_factory.TriggerUrlFor(firstWorkflowType), request.RequestUri?.ToString());
     }
+
+    [Fact]
+    public async Task OnInspectionRecordCreated_GatedChain_PersistsDistinctBlobsPerWorkflow()
+    {
+        const string analysisName = "multi-step-gated-test";
+        var record = await _db.NewInspectionRecord();
+
+        await OnInspectionRecordCreatedInScope(
+            _db.NewInspectionRecordCreatedEvent(record, requiredAnalysis: [analysisName])
+        );
+
+        var analysis = await _context
+            .Analyses.Include(a => a.Runs)
+                .ThenInclude(r => r.Workflows)
+                    .ThenInclude(w => w.InputBlobStorageLocations)
+            .SingleAsync(a => a.Name == analysisName, TestContext.Current.CancellationToken);
+
+        var run = Assert.Single(analysis.Runs);
+        var workflows = run.Workflows.OrderBy(w => w.StepNumber).ToList();
+        Assert.Equal(3, workflows.Count);
+
+        // Each Workflow's owned inputs/output must be distinct CLR instances so EF's
+        // OwnsMany / OwnsOne tracking assigns rows to a single owner.
+        var allOwnedBlobs = workflows
+            .SelectMany(w => w.InputBlobStorageLocations)
+            .Concat(workflows.Select(w => w.OutputBlobStorageLocation!))
+            .ToList();
+        Assert.Equal(allOwnedBlobs.Count, allOwnedBlobs.Distinct().Count());
+
+        // Step 2 is the gate; step 3 must inherit step 2's input (the pre-gate output of step 1),
+        // not step 2's own output — and the blobs must be equal-by-value but distinct instances.
+        var preGateOutput = workflows[0].OutputBlobStorageLocation!;
+        var gateInput = Assert.Single(workflows[1].InputBlobStorageLocations);
+        var postGateInput = Assert.Single(workflows[2].InputBlobStorageLocations);
+        Assert.Equal(preGateOutput.BlobName, gateInput.BlobName);
+        Assert.Equal(preGateOutput.BlobName, postGateInput.BlobName);
+        Assert.NotSame(preGateOutput, gateInput);
+        Assert.NotSame(gateInput, postGateInput);
+    }
 }

--- a/api.Tests/Services/WorkflowServiceTests.cs
+++ b/api.Tests/Services/WorkflowServiceTests.cs
@@ -290,4 +290,129 @@ public class WorkflowServiceTests : IAsyncLifetime
         public Task OnWorkflowCompleted(Workflow workflow) =>
             throw new InvalidOperationException("handler failure for testing");
     }
+
+    [Fact]
+    public async Task OnWorkflowCompleted_GateMatches_SkipsDownstreamWorkflows()
+    {
+        var analysis = await _db.NewAnalysis();
+        var run = await _db.NewAnalysisRun(analysis);
+        var gate = await _db.NewWorkflow(run, workflowType: "test-gate", stepNumber: 1);
+        gate.Status = WorkflowStatus.Succeeded;
+        gate.ResultJson = JsonSerializer.Serialize(new { skip = true });
+        var downstream = await _db.NewWorkflow(
+            run,
+            workflowType: "test-workflow-2",
+            stepNumber: 2,
+            outputBlobStorageLocation: _db.NewBlobStorageLocation()
+        );
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await OnWorkflowCompletedInScope(gate.Id);
+
+        await _context.Entry(run).ReloadAsync(TestContext.Current.CancellationToken);
+        await _context.Entry(downstream).ReloadAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(AnalysisRunStatus.Skipped, run.Status);
+        Assert.NotNull(run.SkipReason);
+        Assert.Equal(WorkflowStatus.Skipped, downstream.Status);
+        Assert.Empty(_factory.ArgoHttpHandler.Requests);
+    }
+
+    [Fact]
+    public async Task OnWorkflowCompleted_GateDoesNotMatch_ContinuesToNextWorkflow()
+    {
+        const string nextWorkflowType = "test-workflow-2";
+        var analysis = await _db.NewAnalysis();
+        var run = await _db.NewAnalysisRun(analysis);
+        var gate = await _db.NewWorkflow(run, workflowType: "test-gate", stepNumber: 1);
+        gate.Status = WorkflowStatus.Succeeded;
+        gate.ResultJson = JsonSerializer.Serialize(new { skip = false });
+        await _db.NewWorkflow(
+            run,
+            workflowType: nextWorkflowType,
+            stepNumber: 2,
+            outputBlobStorageLocation: _db.NewBlobStorageLocation()
+        );
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await OnWorkflowCompletedInScope(gate.Id);
+
+        var request = Assert.Single(_factory.ArgoHttpHandler.Requests);
+        Assert.Equal(_factory.TriggerUrlFor(nextWorkflowType), request.RequestUri?.ToString());
+    }
+
+    [Fact]
+    public async Task OnWorkflowCompleted_GateResultMissing_SkipsChainFailClosed()
+    {
+        const string nextWorkflowType = "test-workflow-2";
+        var analysis = await _db.NewAnalysis();
+        var run = await _db.NewAnalysisRun(analysis);
+        var gate = await _db.NewWorkflow(run, workflowType: "test-gate", stepNumber: 1);
+        gate.Status = WorkflowStatus.Succeeded;
+        gate.ResultJson = null;
+        var downstream = await _db.NewWorkflow(
+            run,
+            workflowType: nextWorkflowType,
+            stepNumber: 2,
+            outputBlobStorageLocation: _db.NewBlobStorageLocation()
+        );
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await OnWorkflowCompletedInScope(gate.Id);
+
+        await _context.Entry(run).ReloadAsync(TestContext.Current.CancellationToken);
+        await _context.Entry(downstream).ReloadAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(AnalysisRunStatus.Skipped, run.Status);
+        Assert.Equal(WorkflowStatus.Skipped, downstream.Status);
+        Assert.Empty(_factory.ArgoHttpHandler.Requests);
+    }
+
+    [Fact]
+    public async Task RetryWorkflow_OnGate_ResetsSkippedRunAndDownstreamSiblings()
+    {
+        const string gateType = "test-gate";
+        var analysis = await _db.NewAnalysis();
+        var run = await _db.NewAnalysisRun(analysis);
+        var gate = await _db.NewWorkflow(
+            run,
+            workflowType: gateType,
+            stepNumber: 1,
+            outputBlobStorageLocation: _db.NewBlobStorageLocation()
+        );
+        gate.Status = WorkflowStatus.Succeeded;
+        gate.ResultJson = "{\"skip\":true}";
+        gate.CompletedAt = DateTime.UtcNow;
+        var downstream = await _db.NewWorkflow(
+            run,
+            workflowType: "test-workflow-2",
+            stepNumber: 2,
+            outputBlobStorageLocation: _db.NewBlobStorageLocation()
+        );
+        downstream.Status = WorkflowStatus.Skipped;
+        downstream.CompletedAt = DateTime.UtcNow;
+        run.Status = AnalysisRunStatus.Skipped;
+        run.SkipReason = "previous skip";
+        run.CompletedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            await ResolveService(scope).RetryWorkflow(gate.Id);
+        }
+
+        await _context.Entry(run).ReloadAsync(TestContext.Current.CancellationToken);
+        await _context.Entry(gate).ReloadAsync(TestContext.Current.CancellationToken);
+        await _context.Entry(downstream).ReloadAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(AnalysisRunStatus.InProgress, run.Status);
+        Assert.Null(run.SkipReason);
+        Assert.Null(run.CompletedAt);
+        Assert.Equal(WorkflowStatus.InProgress, gate.Status);
+        Assert.Null(gate.ResultJson);
+        Assert.Equal(WorkflowStatus.Pending, downstream.Status);
+        Assert.Null(downstream.CompletedAt);
+        var request = Assert.Single(_factory.ArgoHttpHandler.Requests);
+        Assert.Equal(_factory.TriggerUrlFor(gateType), request.RequestUri?.ToString());
+    }
 }

--- a/api.Tests/appsettings.Test.json
+++ b/api.Tests/appsettings.Test.json
@@ -45,6 +45,9 @@
       "multi-step-test": {
         "Workflows": ["test-workflow-1", "test-workflow-2"]
       },
+      "multi-step-gated-test": {
+        "Workflows": ["test-workflow-1", "test-gate", "test-workflow-2"]
+      },
       "group-test": {
         "Workflows": ["test-workflow-1"]
       },
@@ -76,6 +79,17 @@
         "OutputStorageAccount": "outstorage",
         "OutputBlobContainer": "out-container",
         "OutputFileExtension": ".json"
+      },
+      "test-gate": {
+        "TriggerUrl": "http://argo.invalid/api/v1/workflows/test-gate",
+        "OutputStorageAccount": "outstorage",
+        "OutputBlobContainer": "out-container",
+        "OutputFileExtension": ".json",
+        "IsGate": true,
+        "SkipChainIf": {
+          "ResultJsonKeyToCheckForSkipBoolean": "skip",
+          "Value": "true"
+        }
       }
     },
     "DefaultAnalysisByFileExtension": {

--- a/api/Configurations/AnalysisOptions.cs
+++ b/api/Configurations/AnalysisOptions.cs
@@ -29,4 +29,15 @@ public class WorkflowConfig
     public required string OutputBlobContainer { get; set; }
 
     public string? OutputFileExtension { get; set; }
+
+    public bool IsGate { get; set; }
+
+    public SkipRule? SkipChainIf { get; set; }
+}
+
+public class SkipRule
+{
+    public required string ResultJsonKeyToCheckForSkipBoolean { get; set; }
+
+    public required string Value { get; set; }
 }

--- a/api/Database/Models/AnalysisRun.cs
+++ b/api/Database/Models/AnalysisRun.cs
@@ -10,6 +10,7 @@ public enum AnalysisRunStatus
     InProgress,
     Succeeded,
     Failed,
+    Skipped,
 }
 
 public class AnalysisRun
@@ -32,6 +33,8 @@ public class AnalysisRun
     public DateTime? StartedAt { get; set; }
 
     public DateTime? CompletedAt { get; set; }
+
+    public string? SkipReason { get; set; }
 
     public List<Workflow> Workflows { get; set; } = [];
 }

--- a/api/Database/Models/Workflow.cs
+++ b/api/Database/Models/Workflow.cs
@@ -11,6 +11,7 @@ public enum WorkflowStatus
     InProgress,
     Succeeded,
     Failed,
+    Skipped,
 }
 
 [Owned]
@@ -26,6 +27,14 @@ public class BlobStorageLocation
     public required string BlobName { get; set; }
 
     public override string ToString() => $"{StorageAccount}/{BlobContainer}/{BlobName}";
+
+    public BlobStorageLocation Clone() =>
+        new()
+        {
+            StorageAccount = StorageAccount,
+            BlobContainer = BlobContainer,
+            BlobName = BlobName,
+        };
 }
 
 public class Workflow

--- a/api/Migrations/20260603125924_AddSkippedStatusAndSkipReason.Designer.cs
+++ b/api/Migrations/20260603125924_AddSkippedStatusAndSkipReason.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using api.Database.Context;
@@ -11,9 +12,11 @@ using api.Database.Context;
 namespace api.Migrations
 {
     [DbContext(typeof(SaraDbContext))]
-    partial class SaraDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603125924_AddSkippedStatusAndSkipReason")]
+    partial class AddSkippedStatusAndSkipReason
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20260603125924_AddSkippedStatusAndSkipReason.cs
+++ b/api/Migrations/20260603125924_AddSkippedStatusAndSkipReason.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSkippedStatusAndSkipReason : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SkipReason",
+                table: "AnalysisRuns",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SkipReason",
+                table: "AnalysisRuns");
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -64,9 +64,14 @@ else
 builder.Services.Configure<AzureAdOptions>(builder.Configuration.GetSection("AzureAd"));
 builder.Services.Configure<EmailOptions>(builder.Configuration.GetSection("Email"));
 builder.Services.Configure<EndpointConfig>(builder.Configuration.GetSection("EndpointConfig"));
-builder.Services.Configure<AnalysisOptions>(
-    builder.Configuration.GetSection(AnalysisOptions.SectionName)
-);
+builder
+    .Services.AddOptions<AnalysisOptions>()
+    .Bind(builder.Configuration.GetSection(AnalysisOptions.SectionName))
+    .Validate(
+        options => options.Workflows.Values.All(w => w.IsGate == (w.SkipChainIf is not null)),
+        "Invalid Analysis.Workflows configuration: IsGate and SkipChainIf must both be set or both be unset on every workflow."
+    )
+    .ValidateOnStart();
 
 builder.Services.AddScoped<IThermalReferenceMetadataService, ThermalReferenceMetadataService>();
 builder.Services.AddScoped<IInspectionRecordService, InspectionRecordService>();

--- a/api/Services/AnalysisTriggerService.cs
+++ b/api/Services/AnalysisTriggerService.cs
@@ -288,6 +288,9 @@ public class AnalysisTriggerService(
         await context.SaveChangesAsync();
 
         // First step takes all input records' blobs; subsequent steps chain on previous output.
+        // Clone every BlobStorageLocation assigned to a workflow's inputs so each Workflow owns its
+        // own copies — sharing instances across owners (InspectionRecord, sibling Workflows, the
+        // current workflow's own output) confuses EF's owned-entity tracking.
         var currentInputs = inspectionRecords.Select(r => r.BlobStorageLocation).ToList();
 
         for (var i = 0; i < workflowChain.Count; i++)
@@ -300,7 +303,7 @@ public class AnalysisTriggerService(
                 AnalysisRun = run,
                 StepNumber = stepNumber,
                 WorkflowType = workflowType,
-                InputBlobStorageLocations = currentInputs,
+                InputBlobStorageLocations = currentInputs.Select(b => b.Clone()).ToList(),
             };
             run.Workflows.Add(workflow);
 
@@ -312,8 +315,12 @@ public class AnalysisTriggerService(
             );
             workflow.OutputBlobStorageLocation = outputLocation;
 
-            // Next step gets the single output of this step.
-            currentInputs = [outputLocation];
+            // Gating steps don't transform the pipeline payload; the next step
+            // keeps consuming the previous non-gating step's output.
+            if (!_options.Workflows[workflowType].IsGate)
+            {
+                currentInputs = [outputLocation];
+            }
         }
 
         await context.SaveChangesAsync();

--- a/api/Services/WorkflowService.cs
+++ b/api/Services/WorkflowService.cs
@@ -202,6 +202,11 @@ public class WorkflowService(
 
         await DispatchWorkflowResultHandler(workflow);
 
+        if (await TrySkipChainIfGateDictates(workflow, run))
+        {
+            return;
+        }
+
         var nextWorkflow = run
             .Workflows.OrderBy(w => w.StepNumber)
             .FirstOrDefault(w => w.StepNumber > workflow.StepNumber);
@@ -241,6 +246,121 @@ public class WorkflowService(
         await context.SaveChangesAsync();
 
         await OnWorkflowCompleted(workflow.Id);
+    }
+
+    private async Task<bool> TrySkipChainIfGateDictates(Workflow workflow, AnalysisRun run)
+    {
+        if (
+            workflow.Status != WorkflowStatus.Succeeded
+            || !_options.Workflows.TryGetValue(workflow.WorkflowType, out var workflowConfig)
+            || !workflowConfig.IsGate
+            || workflowConfig.SkipChainIf is null
+        )
+        {
+            return false;
+        }
+
+        var skipReason = EvaluateSkipRule(workflow, workflowConfig.SkipChainIf);
+        if (skipReason is null)
+        {
+            return false;
+        }
+
+        var skippedWorkflows = run
+            .Workflows.Where(w =>
+                w.StepNumber > workflow.StepNumber && w.Status == WorkflowStatus.Pending
+            )
+            .ToList();
+
+        foreach (var pending in skippedWorkflows)
+        {
+            pending.Status = WorkflowStatus.Skipped;
+            pending.CompletedAt = DateTime.UtcNow;
+        }
+
+        run.Status = AnalysisRunStatus.Skipped;
+        run.SkipReason = skipReason;
+        run.CompletedAt = DateTime.UtcNow;
+        await context.SaveChangesAsync();
+
+        logger.LogInformation(
+            "AnalysisRun {AnalysisRunId} skipped by gate {GatingWorkflow} "
+                + "(step {StepNumber}). Marked {SkippedCount} downstream workflow(s) "
+                + "[{SkippedTypes}] as Skipped. Reason: {SkipReason}",
+            run.Id,
+            workflow.WorkflowType,
+            workflow.StepNumber,
+            skippedWorkflows.Count,
+            string.Join(", ", skippedWorkflows.Select(w => w.WorkflowType)),
+            skipReason
+        );
+
+        return true;
+    }
+
+    private string? EvaluateSkipRule(Workflow workflow, SkipRule rule)
+    {
+        logger.LogDebug(
+            "Evaluating skip rule for gate workflow {WorkflowType} with Id: {WorkflowId}",
+            workflow.WorkflowType,
+            workflow.Id
+        );
+
+        string? actualValue = null;
+        string? failReason = null;
+
+        if (string.IsNullOrWhiteSpace(workflow.ResultJson))
+        {
+            failReason = "Gate result missing";
+        }
+        else
+        {
+            try
+            {
+                using var result = JsonDocument.Parse(workflow.ResultJson);
+                if (
+                    result.RootElement.TryGetProperty(
+                        rule.ResultJsonKeyToCheckForSkipBoolean,
+                        out var node
+                    )
+                )
+                    actualValue = node.ToString();
+                else
+                    failReason =
+                        $"Gate result missing field '{rule.ResultJsonKeyToCheckForSkipBoolean}'";
+            }
+            catch (JsonException)
+            {
+                failReason = "Gate result unparseable";
+            }
+        }
+
+        if (failReason is not null)
+        {
+            logger.LogWarning(
+                "Gate workflow {WorkflowType} with Id: {WorkflowId} cannot be evaluated, skipping chain as a precaution: {Error}",
+                workflow.WorkflowType,
+                workflow.Id,
+                failReason
+            );
+            return $"{workflow.WorkflowType} gate could not be evaluated: {failReason}, skipping chain as a precaution";
+        }
+
+        var matches = string.Equals(actualValue, rule.Value, StringComparison.OrdinalIgnoreCase);
+
+        logger.LogDebug(
+            "Gate workflow {WorkflowType} with Id: {WorkflowId}: expected {Key}={Expected} and received {Key}={Actual}",
+            workflow.WorkflowType,
+            workflow.Id,
+            rule.ResultJsonKeyToCheckForSkipBoolean,
+            rule.Value,
+            rule.ResultJsonKeyToCheckForSkipBoolean,
+            actualValue
+        );
+
+        return matches
+            ? $"{workflow.WorkflowType} gate matched: {rule.ResultJsonKeyToCheckForSkipBoolean}={rule.Value}"
+            : null;
     }
 
     private async Task DispatchWorkflowResultHandler(Workflow workflow)
@@ -368,10 +488,30 @@ public class WorkflowService(
         var run = await context.AnalysisRuns.FirstOrDefaultAsync(r =>
             r.Id == workflow.AnalysisRunId
         );
-        if (run is not null && run.Status == AnalysisRunStatus.Failed)
+        if (
+            run is not null
+            && (run.Status == AnalysisRunStatus.Failed || run.Status == AnalysisRunStatus.Skipped)
+        )
         {
             run.Status = AnalysisRunStatus.InProgress;
             run.CompletedAt = null;
+            run.SkipReason = null;
+        }
+
+        var skippedSiblings = await context
+            .Workflows.Where(w =>
+                w.AnalysisRunId == workflow.AnalysisRunId
+                && w.Id != workflow.Id
+                && w.Status == WorkflowStatus.Skipped
+            )
+            .ToListAsync();
+        foreach (var sibling in skippedSiblings)
+        {
+            sibling.Status = WorkflowStatus.Pending;
+            sibling.StartedAt = null;
+            sibling.CompletedAt = null;
+            sibling.ErrorMessage = null;
+            sibling.ResultJson = null;
         }
 
         await context.SaveChangesAsync();

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -46,8 +46,8 @@
   "Analysis": {
     "Analyses": {
       "anonymize": { "Workflows": ["anonymizer"] },
-      "fencilla": { "Workflows": ["anonymizer", "fencilla"] },
-      "cloe": { "Workflows": ["anonymizer", "cloe"] },
+      "fencilla": { "Workflows": ["anonymizer", "rain-drop", "fencilla"] },
+      "cloe": { "Workflows": ["anonymizer", "rain-drop", "cloe"] },
       "thermal-reading": { "Workflows": ["anonymizer", "thermal-reading"] }
     },
     "Workflows": {
@@ -56,6 +56,14 @@
         "OutputStorageAccount": "saradevstoreanon",
         "OutputBlobContainer": "",
         "OutputFileExtension": ".jpg"
+      },
+      "rain-drop": {
+        "TriggerUrl": "http://trigger-rain-drop-source:8080/trigger-rain-drop",
+        "OutputStorageAccount": "saradevstorevis",
+        "OutputBlobContainer": "",
+        "OutputFileExtension": ".json",
+        "IsGate": true,
+        "SkipChainIf": { "ResultJsonKeyToCheckForSkipBoolean": "rain", "Value": "true" }
       },
       "fencilla": {
         "TriggerUrl": "http://trigger-fencilla-source:8080/trigger-fencilla",

--- a/workflow-notifier/mocks/argo_workflow_mock.py
+++ b/workflow-notifier/mocks/argo_workflow_mock.py
@@ -96,6 +96,19 @@ def trigger_fencilla():
     return jsonify({"message": "Fencilla triggered"}), 200
 
 
+@flask_app.route("/trigger-rain-drop", methods=["POST"])
+def trigger_rain_drop():
+    data = request.get_json()
+    print(f"Received rain-drop trigger: {data}")
+    workflow_id = _extract_workflow_id(data)
+    if workflow_id is None:
+        return jsonify({"error": "workflowId missing"}), 400
+
+    payload = {"rain": random.random() < 0.2}
+    threading.Thread(target=_run_workflow, args=(workflow_id, payload)).start()
+    return jsonify({"message": "Rain-drop triggered"}), 200
+
+
 @flask_app.route("/trigger-thermal-reading", methods=["POST"])
 def trigger_thermal_reading():
     data = request.get_json()


### PR DESCRIPTION
Add rain-drop gating workflow

Introduces a "gate" concept for workflows: a step that decides whether the rest of the chain should run. The rain-drop pod is the first gate: when it reports rain, fencilla and cloe are skipped for that run.

Schema
- New AnalysisRunStatus.Skipped and WorkflowStatus.Skipped enum values (stored as integers, no schema impact).
- New nullable SkipReason column on AnalysisRuns to record why a run was skipped.

Configuration

WorkflowConfig gains two optional fields:
- IsGate: marks the workflow as a gating step.
- SkipChainIf: { ResultJsonKeyToCheckForSkipBoolean, Value }: skip the chain if the gate's ResultJson contains the given key with the given value.

Rain-drop entry added to appsettings.json with IsGate: true and SkipChainIf: { ResultJsonKeyToCheckForSkipBoolean: "rain", Value: "true" }.

Pipeline behaviour

- WorkflowService.OnWorkflowCompleted: after a successful gate, the gate's ResultJson is inspected. On a match, all downstream Pending workflows are marked Skipped, the run is marked Skipped with a SkipReason, and no further workflows are triggered.
- Fail-close: if the gate's result is missing, unparseable, or does not contain the expected field, a Warning is logged and the chain is skipped as a precaution.
- AnalysisTriggerService now clones BlobStorageLocation instances per workflow to keep EF OwnsMany ownership clean across gated chains.
- RetryWorkflow now also resets Skipped runs (clears SkipReason) and flips any downstream Skipped sibling workflows back to Pending so the chain can re-run.

Note: skipped runs do not emit an MQTT analysis-result message.

Tests

- WorkflowServiceTests: gate matches and skips downstream; gate does not match and chain continues; gate result missing and chain is skipped (fail-close); retrying a gate resets the Skipped run and its Skipped sibling workflows.
- AnalysisTriggerServiceTests: round-trip persistence of a gated chain: every workflow's owned BlobStorageLocations are distinct DB rows after SaveChanges.