### PR TITLE
Validate Database:Server/User/PostgresDatabase non-empty in AppRegIdentity

### DIFF
--- a/api/Configurations/CustomServiceConfigurations.cs
+++ b/api/Configurations/CustomServiceConfigurations.cs
@@ -365,19 +365,19 @@ public static class CustomServiceConfigurations
         IConfiguration configuration
     )
     {
-        var server =
-            configuration["Database:Server"]
-            ?? throw new InvalidOperationException(
+        var server = configuration["Database:Server"];
+        if (string.IsNullOrWhiteSpace(server))
+            throw new InvalidOperationException(
                 "Database:Server is required for AppRegIdentity auth."
             );
-        var postgresDb =
-            configuration["Database:PostgresDatabase"]
-            ?? throw new InvalidOperationException(
+        var postgresDb = configuration["Database:PostgresDatabase"];
+        if (string.IsNullOrWhiteSpace(postgresDb))
+            throw new InvalidOperationException(
                 "Database:PostgresDatabase is required for AppRegIdentity auth."
             );
-        var dbUser =
-            configuration["Database:User"]
-            ?? throw new InvalidOperationException(
+        var dbUser = configuration["Database:User"];
+        if (string.IsNullOrWhiteSpace(dbUser))
+            throw new InvalidOperationException(
                 "Database:User is required for AppRegIdentity auth."
             );
 


### PR DESCRIPTION
Tighten validation in `ConfigureDatabaseWithAppRegIdentity` from `?? throw` (null-only) to `string.IsNullOrWhiteSpace ? throw` so empty-string defaults in `appsettings.json` are rejected.

Without this, the AppRegIdentity path silently succeeded with empty `Database:Server`, producing a malformed Npgsql connection string `tcp://.postgres.database.azure.com:5432` and DNS failures. Observed in `robotics-analytics-dev` after the SPC clientID flip (analytics-infrastructure#289), once the workload-identity token started being acquired successfully against the sara app-reg. The empty values come from base `appsettings.json:23-25` which seeds `Server`/`PostgresDatabase`/`User` as `""`; the existing null-check let them through and the path no longer fell back to ConnectionString. With this fix the path throws cleanly and `ConnectionString` (Key Vault) takes over.