### PR TITLE
Remove ClientSecret from AzureAd AllowedAuthMethods in staging/production

### DIFF
--- a/api/appsettings.Production.json
+++ b/api/appsettings.Production.json
@@ -1,7 +1,7 @@
 {
   "AzureAd": {
     "ClientId": "7d167947-b236-47ab-baa0-3d3575334237",
-    "AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret", "AzureCliBootstrap" ]
+    "AllowedAuthMethods": [ "WorkloadIdentity", "AzureCliBootstrap" ]
   },
   "Logging": {
     "LogLevel": {

--- a/api/appsettings.Staging.json
+++ b/api/appsettings.Staging.json
@@ -1,7 +1,7 @@
 {
   "AzureAd": {
     "ClientId": "47a40d36-25a0-434c-8de2-94f703fb57f4",
-    "AllowedAuthMethods": [ "WorkloadIdentity", "ClientSecret", "AzureCliBootstrap" ]
+    "AllowedAuthMethods": [ "WorkloadIdentity", "AzureCliBootstrap" ]
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Drops `ClientSecret` from `AzureAd:AllowedAuthMethods` in staging and production appsettings, leaving `WorkloadIdentity` and `AzureCliBootstrap`. Both environments have been running on WI since v1.0.9; client-secret fallback is no longer needed.

Development retains `ClientSecret` for local `.env`-based dev. Pairs with analytics-infrastructure#290 which removes `AZURE_CLIENT_SECRET` env var from the pod.