### PR TITLE
Wire Database:Server/User/PostgresDatabase for dev AppRegIdentity

### DIFF
--- a/api/appsettings.Development.json
+++ b/api/appsettings.Development.json
@@ -18,7 +18,10 @@
   ],
   "Database": {
     "UseInMemoryDatabase": false,
-    "AllowedAuthMethods": [ "AppRegIdentity", "ConnectionString" ]
+    "AllowedAuthMethods": [ "AppRegIdentity", "ConnectionString" ],
+    "Server": "robotics-dev-psql-server",
+    "PostgresDatabase": "sara",
+    "User": "sara-dev"
   },
   "KeyVault": {
     "VaultUri": "https://saradev-kv.vault.azure.net/"


### PR DESCRIPTION
Populates the three required `Database:*` config keys on the Development overlay so the existing `AppRegIdentity` auth path (PR #391) can acquire an Entra ID token and connect to `robotics-dev-psql-server`/`sara` as the `sara-dev` app registration. `ConnectionString` remains as a fallback during the migration window — once dev runtime + CI migration are verified using AppRegIdentity, a follow-up PR drops the fallback.

DBA prerequisite (run once, separately): create the `sara-dev` AAD principal in PG, grant CRUD+sequence privileges on `sara` DB, and transfer existing table ownership from `postgresuser`. SQL is staged in `phase5-sara-pg-entra-id.sql` (DEV section). Until that's run, AppRegIdentity will fail at startup and the existing ConnectionString fallback continues to serve traffic — so this PR is safe to merge before or after the DBA work.