### PR TITLE
Add disabling tls mqtt for local dev

### DIFF
--- a/api/MQTT/MqttService.cs
+++ b/api/MQTT/MqttService.cs
@@ -50,17 +50,24 @@ namespace api.MQTT
             _maxRetryAttempts = mqttConfig.GetValue<int>("MaxRetryAttempts");
             _shouldFailOnMaxRetries = mqttConfig.GetValue<bool>("ShouldFailOnMaxRetries");
 
-            var tlsOptions = new MqttClientTlsOptions
-            {
-                UseTls = true,
-                /* Currently disabled to use self-signed certificate in the internal broker communication */
-                //if (_notProduction)
-                IgnoreCertificateChainErrors = true,
-            };
+            bool allowInsecure = mqttConfig.GetValue<bool>("AllowInsecureLocalConnections");
+
             var builder = new MqttClientOptionsBuilder()
                 .WithTcpServer(_serverHost, _serverPort)
-                .WithTlsOptions(tlsOptions)
                 .WithCredentials(username, password);
+
+            if (allowInsecure)
+            {
+                _logger.LogWarning(
+                    "MQTT TLS disabled — insecure connections allowed. Do NOT use in production."
+                );
+            }
+            else
+            {
+                builder.WithTlsOptions(
+                    new MqttClientTlsOptions { UseTls = true, IgnoreCertificateChainErrors = true }
+                );
+            }
 
             _options = new ManagedMqttClientOptionsBuilder()
                 .WithAutoReconnectDelay(_reconnectDelay)

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -41,7 +41,8 @@
       "isar/+/inspection_value"
     ],
     "MaxRetryAttempts": 5,
-    "ShouldFailOnMaxRetries": false
+    "ShouldFailOnMaxRetries": false,
+    "AllowInsecureLocalConnections": false
   },
   "Analysis": {
     "Analyses": {


### PR DESCRIPTION
## Ready for review checklist:

- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.

Makes it possible to opt-in to not use TLS with mqtt via env vars (defaults to requiring TLS).

Useful for local dev as it makes the setup easier