### PR TITLE
Cache runtime credential to deduplicate token requests

### DIFF
--- a/api/Configurations/CustomServiceConfigurations.cs
+++ b/api/Configurations/CustomServiceConfigurations.cs
@@ -15,6 +15,17 @@ public static class CustomServiceConfigurations
 {
     private const string AzurePostgresScope = "https://ossrdbms-aad.database.windows.net/.default";
 
+    // The runtime credential is built once at startup and reused for both the
+    // initial Entra ID token probe (ConfigureDatabaseWithAppRegIdentity) and
+    // the periodic password provider attached to the Npgsql data source.
+    // Sharing a single ChainedTokenCredential instance lets MSAL deduplicate
+    // concurrent token requests on cold start, eliminates a duplicated
+    // "Runtime ClientSecretCredential configured" log line, and avoids a race
+    // where one of two parallel acquisitions is cancelled with
+    // OperationCanceledException.
+    private static readonly object s_runtimeCredentialLock = new();
+    private static TokenCredential? s_runtimeCredential;
+
     public static TokenCredential CreateCredential(IConfiguration config)
     {
         string? tenantId = config["AzureAd:TenantId"];
@@ -136,6 +147,21 @@ public static class CustomServiceConfigurations
     }
 
     public static TokenCredential CreateRuntimeCredential(IConfiguration config)
+    {
+        if (s_runtimeCredential is not null)
+            return s_runtimeCredential;
+
+        lock (s_runtimeCredentialLock)
+        {
+            if (s_runtimeCredential is not null)
+                return s_runtimeCredential;
+
+            s_runtimeCredential = BuildRuntimeCredential(config);
+            return s_runtimeCredential;
+        }
+    }
+
+    private static TokenCredential BuildRuntimeCredential(IConfiguration config)
     {
         string? tenantId = config["AzureAd:TenantId"];
         string? clientId = config["AzureAd:ClientId"];


### PR DESCRIPTION
## Summary
On cold start `CreateRuntimeCredential` is invoked twice — once for the synchronous Entra ID token probe in `ConfigureDatabaseWithAppRegIdentity` and once inside `ConfigureDataSource`'s periodic password provider. Each call instantiated a fresh `ChainedTokenCredential`, producing duplicated `Runtime ClientSecretCredential configured` log lines and a race where one of two concurrent MSAL token acquisitions was cancelled with `OperationCanceledException`.

## Change
Memoize the credential behind a static, lock-guarded field. First call builds + logs the chain; subsequent calls return the cached instance. MSAL's internal request deduplication then collapses the parallel acquisitions into one.

## Notes
Draft. Posted alongside an alternative approach (skip `ClientSecret` in chain when `AZURE_FEDERATED_TOKEN_FILE` is set) for comparison; pick one to land.