### PR TITLE
Wire Database:Server/User/PostgresDatabase for staging AppRegIdentity

### DIFF
--- a/api/appsettings.Staging.json
+++ b/api/appsettings.Staging.json
@@ -17,7 +17,10 @@
   ],
   "Database": {
     "UseInMemoryDatabase": false,
-    "AllowedAuthMethods": [ "AppRegIdentity", "ConnectionString" ]
+    "AllowedAuthMethods": [ "AppRegIdentity", "ConnectionString" ],
+    "Server": "robotics-staging-psql-server",
+    "PostgresDatabase": "sara",
+    "User": "sara-staging"
   },
   "KeyVault": {
     "VaultUri": "https://sarastaging-kv.vault.azure.net/"


### PR DESCRIPTION
## Summary
Mirror of #396 for staging. Adds `Database:Server`, `Database:PostgresDatabase`, and `Database:User` so `AppRegIdentity` can resolve a host on the staging pod the same way dev does today.

## Notes
Do not merge yet. Staging DBA SQL (grant CRUD on `sara` DB to the `sara-staging` AAD principal) and a migration smoke test must run first. After merge: standard staging release, ArgoCD sync, verify pod logs show `AppRegIdentity configured successfully.`.