### PR TITLE
Wire Database:Server/User/PostgresDatabase for prod AppRegIdentity

### DIFF
--- a/api/appsettings.Production.json
+++ b/api/appsettings.Production.json
@@ -17,7 +17,10 @@
   ],
   "Database": {
     "UseInMemoryDatabase": false,
-    "AllowedAuthMethods": [ "AppRegIdentity", "ConnectionString" ]
+    "AllowedAuthMethods": [ "AppRegIdentity", "ConnectionString" ],
+    "Server": "robotics-prod-psql-server",
+    "PostgresDatabase": "sara",
+    "User": "sara-prod"
   },
   "KeyVault": {
     "VaultUri": "https://saraprod-kv.vault.azure.net/"


### PR DESCRIPTION
## Summary

Mirror of #396 (dev) and #405 (staging) for the production environment. Adds `Database:Server`, `Database:PostgresDatabase`, and `Database:User` to `appsettings.Production.json` so the runtime can build the Entra ID-authenticated EF Core connection string against `robotics-prod-psql-server` as the `sara-prod` Postgres principal. Without these keys `ConfigureDatabaseWithAppRegIdentity` throws at startup and the chain falls through to `ConnectionString`.

`AllowedAuthMethods` is unchanged (`["AppRegIdentity", "ConnectionString"]`); the `ConnectionString` fallback remains in place permanently as the migration auth path (see armada#73). DBA grants for the `sara-prod` principal will be applied out-of-band before promoting v1.0.12 to prod.