### PR TITLE
Add copy-raw-to-visualized passthrough workflow

### DIFF
--- a/api.Tests/Services/AnalysisTriggerServiceTests.cs
+++ b/api.Tests/Services/AnalysisTriggerServiceTests.cs
@@ -84,6 +84,20 @@ public class AnalysisTriggerServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task OnInspectionRecordCreated_InspectionTypeAndExtension_TakesPrecedenceOverFileExtension()
+    {
+        var record = await _db.NewInspectionRecord(
+            inspectionType: "TestVideo",
+            blobName: "clip.mp4"
+        );
+
+        await OnInspectionRecordCreatedInScope(_db.NewInspectionRecordCreatedEvent(record));
+
+        var analysis = await LoadOnlyAnalysisAsync();
+        Assert.Equal("multi-step-test", analysis.Name);
+    }
+
+    [Fact]
     public async Task OnInspectionRecordCreated_MixedKnownAndUnknownAnalyses_RunsKnownSkipsUnknown()
     {
         const string knownAnalysis = "per-record-test";

--- a/api.Tests/Services/ResultHandlers/WorkflowResultHandlers/CopyRawToVisualizedResultHandlerTests.cs
+++ b/api.Tests/Services/ResultHandlers/WorkflowResultHandlers/CopyRawToVisualizedResultHandlerTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using api.Database.Context;
+using api.Services.ResultHandlers.WorkflowResultHandlers;
+using Api.Test.Database;
+using Microsoft.Extensions.DependencyInjection;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Api.Test.Services.ResultHandlers.WorkflowResultHandlers;
+
+public class CopyRawToVisualizedResultHandlerTests : IAsyncLifetime
+{
+    private PostgreSqlContainer _container = null!;
+    private TestWebApplicationFactory<Program> _factory = null!;
+    private SaraDbContext _context = null!;
+    private DatabaseUtilities _db = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        (_container, string cs) = await TestSetupHelpers.ConfigurePostgreSqlDatabase();
+        _factory = TestSetupHelpers.ConfigureWebApplicationFactory(cs);
+        _ = _factory.Services;
+        _context = TestSetupHelpers.ConfigurePostgreSqlContext(cs);
+        _db = new DatabaseUtilities(_context);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        await _factory.DisposeAsync();
+        await _container.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    private CopyRawToVisualizedResultHandler ResolveHandler(IServiceScope scope) =>
+        scope
+            .ServiceProvider.GetRequiredService<IEnumerable<IWorkflowResultHandler>>()
+            .OfType<CopyRawToVisualizedResultHandler>()
+            .Single();
+
+    [Fact]
+    public async Task OnWorkflowCompleted_ValidSingleRecordWithOutput_PublishesVisualizationAvailable()
+    {
+        const string inspectionId = "insp-123";
+        const string blobName = "raw.mp4";
+        var record = await _db.NewInspectionRecord(inspectionId: inspectionId);
+        var analysis = await _db.NewAnalysis(inspectionRecords: [record]);
+        var run = await _db.NewAnalysisRun(analysis);
+        var output = _db.NewBlobStorageLocation(blobName: blobName);
+        var workflow = await _db.NewWorkflow(
+            run,
+            workflowType: "copy-raw-to-visualized",
+            outputBlobStorageLocation: output
+        );
+
+        using var scope = _factory.Services.CreateScope();
+        var handler = ResolveHandler(scope);
+
+        await handler.OnWorkflowCompleted(workflow);
+
+        var published = Assert.Single(_factory.MqttPublisher.VisualizationMessages);
+        Assert.Equal(inspectionId, published.InspectionId);
+        Assert.Equal(blobName, published.BlobName);
+    }
+
+    [Fact]
+    public async Task OnWorkflowCompleted_GroupAnalysisWithMultipleRecords_DoesNotPublish()
+    {
+        var record1 = await _db.NewInspectionRecord(inspectionId: "insp-1");
+        var record2 = await _db.NewInspectionRecord(inspectionId: "insp-2");
+        var analysis = await _db.NewAnalysis(inspectionRecords: [record1, record2]);
+        var run = await _db.NewAnalysisRun(analysis);
+        var output = _db.NewBlobStorageLocation();
+        var workflow = await _db.NewWorkflow(
+            run,
+            workflowType: "copy-raw-to-visualized",
+            outputBlobStorageLocation: output
+        );
+
+        using var scope = _factory.Services.CreateScope();
+        var handler = ResolveHandler(scope);
+
+        await handler.OnWorkflowCompleted(workflow);
+
+        Assert.Empty(_factory.MqttPublisher.VisualizationMessages);
+    }
+}

--- a/api.Tests/Services/WorkflowServiceTests.cs
+++ b/api.Tests/Services/WorkflowServiceTests.cs
@@ -116,6 +116,25 @@ public class WorkflowServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task TriggerWorkflow_PayloadIncludesWorkflowType()
+    {
+        const string workflowType = "test-workflow-1";
+        var analysis = await _db.NewAnalysis();
+        var run = await _db.NewAnalysisRun(analysis);
+        var workflow = await _db.NewWorkflow(
+            run,
+            workflowType: workflowType,
+            outputBlobStorageLocation: _db.NewBlobStorageLocation()
+        );
+
+        await TriggerWorkflowInScope(workflow.Id);
+
+        var request = Assert.Single(_factory.ArgoHttpHandler.Requests);
+        using var doc = JsonDocument.Parse(request.Body);
+        Assert.Equal(workflowType, doc.RootElement.GetProperty("workflowType").GetString());
+    }
+
+    [Fact]
     public async Task TriggerWorkflow_HappyPathWithEnricher_PayloadIncludesEnrichedFields()
     {
         const string installationCode = "HUA";

--- a/api.Tests/appsettings.Test.json
+++ b/api.Tests/appsettings.Test.json
@@ -93,7 +93,11 @@
       }
     },
     "DefaultAnalysisByFileExtension": {
-      ".jpg": ["per-record-test"]
+      ".jpg": ["per-record-test"],
+      ".mp4": ["per-record-test"]
+    },
+    "DefaultAnalysisByInspectionTypeAndExtension": {
+      "TestVideo": { ".mp4": ["multi-step-test"] }
     }
   }
 }

--- a/api/Configurations/AnalysisOptions.cs
+++ b/api/Configurations/AnalysisOptions.cs
@@ -10,6 +10,11 @@ public class AnalysisOptions
 
     public Dictionary<string, List<string>> DefaultAnalysisByFileExtension { get; set; } = [];
 
+    public Dictionary<
+        string,
+        Dictionary<string, List<string>>
+    > DefaultAnalysisByInspectionTypeAndExtension { get; set; } = [];
+
     public int AnalysisGroupTimeoutMinutes { get; set; } = 30;
 
     public int AnalysisGroupTimeoutCheckIntervalSeconds { get; set; } = 60;

--- a/api/Controllers/InspectionRecordController.cs
+++ b/api/Controllers/InspectionRecordController.cs
@@ -14,6 +14,16 @@ public class InspectionRecordController(
     IInspectionRecordService inspectionRecordService
 ) : ControllerBase
 {
+    // Workflow types whose output forms the visualization base layer for an
+    // inspection (anonymized image or raw passthrough). Newest succeeded one wins.
+    private static readonly HashSet<string> VisualizationWorkflowTypes = new(
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        "anonymizer",
+        "copy-raw-to-visualized",
+    };
+
     [HttpGet]
     [Authorize(Roles = Role.Any)]
     [ProducesResponseType(typeof(PagedResponse<InspectionRecord>), StatusCodes.Status200OK)]
@@ -105,7 +115,7 @@ public class InspectionRecordController(
 
     [HttpGet]
     [Authorize(Roles = Role.Any)]
-    [Route("inspection-id/{inspectionId}/anonymized-location")]
+    [Route("inspection-id/{inspectionId}/visualization-location")]
     [ProducesResponseType(typeof(BlobStorageLocation), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -113,7 +123,7 @@ public class InspectionRecordController(
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<BlobStorageLocation>> GetAnonymizedLocation(
+    public async Task<ActionResult<BlobStorageLocation>> GetVisualizationLocation(
         [FromRoute] string inspectionId
     )
     {
@@ -128,47 +138,51 @@ public class InspectionRecordController(
                 );
             }
 
-            var anonymizer = record
+            var visualizationWorkflow = record
                 .Analyses.SelectMany(a => a.Runs)
                 .SelectMany(r => r.Workflows)
-                .Where(w => w.WorkflowType.Equals("anonymizer", StringComparison.OrdinalIgnoreCase))
+                .Where(w => VisualizationWorkflowTypes.Contains(w.WorkflowType))
                 .OrderByDescending(w => w.CompletedAt ?? w.StartedAt ?? DateTime.MinValue)
                 .FirstOrDefault();
 
-            if (anonymizer is null)
+            if (visualizationWorkflow is null)
             {
-                return NotFound($"No anonymizer workflow found for inspection id {inspectionId}");
+                return NotFound(
+                    $"No visualization workflow found for inspection id {inspectionId}"
+                );
             }
 
-            return anonymizer.Status switch
+            return visualizationWorkflow.Status switch
             {
-                WorkflowStatus.Succeeded when anonymizer.OutputBlobStorageLocation is not null =>
-                    Ok(anonymizer.OutputBlobStorageLocation),
+                WorkflowStatus.Succeeded
+                    when visualizationWorkflow.OutputBlobStorageLocation is not null => Ok(
+                    visualizationWorkflow.OutputBlobStorageLocation
+                ),
                 WorkflowStatus.Succeeded => StatusCode(
                     StatusCodes.Status500InternalServerError,
-                    "Anonymizer workflow succeeded but produced no output blob location."
+                    "Visualization workflow succeeded but produced no output blob location."
                 ),
                 WorkflowStatus.Pending => StatusCode(
                     StatusCodes.Status202Accepted,
-                    "Anonymizer workflow has not started."
+                    "Visualization workflow has not started."
                 ),
                 WorkflowStatus.InProgress => StatusCode(
                     StatusCodes.Status202Accepted,
-                    "Anonymizer workflow is in progress."
+                    "Visualization workflow is in progress."
                 ),
                 WorkflowStatus.Failed => StatusCode(
                     StatusCodes.Status422UnprocessableEntity,
-                    "Anonymizer workflow failed."
+                    "Visualization workflow failed."
                 ),
                 _ => StatusCode(
                     StatusCodes.Status500InternalServerError,
-                    "Unknown anonymizer workflow status."
+                    "Unknown visualization workflow status."
                 ),
             };
         }
         catch (Exception e)
         {
-            logger.LogError(e, "Error fetching anonymized location for inspection id");
+            logger.LogError(e, "Error fetching visualization location for inspection id");
             return StatusCode(StatusCodes.Status500InternalServerError, "Internal server error");
         }
     }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -92,6 +92,7 @@ builder.Services.AddScoped<ITriggerPayloadEnricher, ThermalReadingPayloadEnriche
 // Per-workflow result handlers — fire on each successful Workflow step.
 builder.Services.AddScoped<IWorkflowResultHandler, AnonymizerResultHandler>();
 builder.Services.AddScoped<IWorkflowResultHandler, CLOEResultHandler>();
+builder.Services.AddScoped<IWorkflowResultHandler, CopyRawToVisualizedResultHandler>();
 builder.Services.AddScoped<IWorkflowResultHandler, FencillaResultHandler>();
 builder.Services.AddScoped<IWorkflowResultHandler, ThermalReadingResultHandler>();
 

--- a/api/Services/AnalysisTriggerService.cs
+++ b/api/Services/AnalysisTriggerService.cs
@@ -90,10 +90,12 @@ public class AnalysisTriggerService(
     /// <summary>
     /// Returns the configured analyses to run for an InspectionRecord.
     /// Analyses come from the event's explicit <c>RequiredAnalysis</c> when
-    /// set; otherwise from <c>DefaultAnalysisByFileExtension</c>. Names that
-    /// are not present in configuration are dropped with an error log so
-    /// known analyses can still proceed independently. Returns an empty list
-    /// when no analyses apply.
+    /// set; otherwise from <c>DefaultAnalysisByInspectionTypeAndExtension</c>
+    /// (matched on InspectionType + file extension), falling back to
+    /// <c>DefaultAnalysisByFileExtension</c>. Names that are not present in
+    /// configuration are dropped with an error log so known analyses can
+    /// still proceed independently. Returns an empty list when no analyses
+    /// apply.
     /// </summary>
     private List<string> GetAnalysesToRun(
         InspectionRecordCreatedEvent createdEvent,
@@ -109,11 +111,31 @@ public class AnalysisTriggerService(
         {
             var blobName = inspectionRecord.BlobStorageLocation.BlobName;
             var extension = Path.GetExtension(blobName)?.ToLowerInvariant();
-            requestedNames =
+            var inspectionType = inspectionRecord.InspectionType;
+
+            if (
                 extension is not null
-                && _options.DefaultAnalysisByFileExtension.TryGetValue(extension, out var defaults)
-                    ? defaults
-                    : [];
+                && inspectionType is not null
+                && _options.DefaultAnalysisByInspectionTypeAndExtension.TryGetValue(
+                    inspectionType,
+                    out var byExtension
+                )
+                && byExtension.TryGetValue(extension, out var typedDefaults)
+            )
+            {
+                requestedNames = typedDefaults;
+            }
+            else
+            {
+                requestedNames =
+                    extension is not null
+                    && _options.DefaultAnalysisByFileExtension.TryGetValue(
+                        extension,
+                        out var defaults
+                    )
+                        ? defaults
+                        : [];
+            }
         }
 
         if (requestedNames.Count == 0)

--- a/api/Services/AnalysisTriggerService.cs
+++ b/api/Services/AnalysisTriggerService.cs
@@ -113,29 +113,7 @@ public class AnalysisTriggerService(
             var extension = Path.GetExtension(blobName)?.ToLowerInvariant();
             var inspectionType = inspectionRecord.InspectionType;
 
-            if (
-                extension is not null
-                && inspectionType is not null
-                && _options.DefaultAnalysisByInspectionTypeAndExtension.TryGetValue(
-                    inspectionType,
-                    out var byExtension
-                )
-                && byExtension.TryGetValue(extension, out var typedDefaults)
-            )
-            {
-                requestedNames = typedDefaults;
-            }
-            else
-            {
-                requestedNames =
-                    extension is not null
-                    && _options.DefaultAnalysisByFileExtension.TryGetValue(
-                        extension,
-                        out var defaults
-                    )
-                        ? defaults
-                        : [];
-            }
+            requestedNames = ResolveDefaultAnalyses(inspectionType, extension);
         }
 
         if (requestedNames.Count == 0)
@@ -416,6 +394,47 @@ public class AnalysisTriggerService(
 
             await TriggerAnalysis(analysis, groupRecords);
         }
+    }
+
+    private List<string> ResolveDefaultAnalyses(string? inspectionType, string? extension)
+    {
+        return TryGetDefaultAnalysesByInspectionTypeAndExtension(inspectionType, extension)
+            ?? TryGetDefaultAnalysesByExtension(extension)
+            ?? [];
+    }
+
+    private List<string>? TryGetDefaultAnalysesByInspectionTypeAndExtension(
+        string? inspectionType,
+        string? extension
+    )
+    {
+        if (
+            inspectionType is not null
+            && extension is not null
+            && _options.DefaultAnalysisByInspectionTypeAndExtension.TryGetValue(
+                inspectionType,
+                out var byExtension
+            )
+            && byExtension.TryGetValue(extension, out var analyses)
+        )
+        {
+            return analyses;
+        }
+
+        return null;
+    }
+
+    private List<string>? TryGetDefaultAnalysesByExtension(string? extension)
+    {
+        if (
+            extension is not null
+            && _options.DefaultAnalysisByFileExtension.TryGetValue(extension, out var analyses)
+        )
+        {
+            return analyses;
+        }
+
+        return null;
     }
 
     public async Task RerunAnalysis(Guid analysisId)

--- a/api/Services/AnalysisTriggerService.cs
+++ b/api/Services/AnalysisTriggerService.cs
@@ -102,10 +102,10 @@ public class AnalysisTriggerService(
         InspectionRecord inspectionRecord
     )
     {
-        List<string> requestedNames;
+        List<string> analysesToRun;
         if (createdEvent.RequiredAnalysis is { Count: > 0 })
         {
-            requestedNames = createdEvent.RequiredAnalysis;
+            analysesToRun = createdEvent.RequiredAnalysis;
         }
         else
         {
@@ -113,10 +113,10 @@ public class AnalysisTriggerService(
             var extension = Path.GetExtension(blobName)?.ToLowerInvariant();
             var inspectionType = inspectionRecord.InspectionType;
 
-            requestedNames = ResolveDefaultAnalyses(inspectionType, extension);
+            analysesToRun = ResolveDefaultAnalyses(inspectionType, extension);
         }
 
-        if (requestedNames.Count == 0)
+        if (analysesToRun.Count == 0)
         {
             logger.LogInformation(
                 "No analyses to run for InspectionId: {InspectionId}",
@@ -125,7 +125,7 @@ public class AnalysisTriggerService(
             return [];
         }
 
-        var unknownNames = requestedNames
+        var unknownNames = analysesToRun
             .Where(name => !_options.Analyses.ContainsKey(name))
             .ToList();
         if (unknownNames.Count > 0)
@@ -138,7 +138,7 @@ public class AnalysisTriggerService(
             );
         }
 
-        var knownNames = requestedNames.Where(name => _options.Analyses.ContainsKey(name)).ToList();
+        var knownNames = analysesToRun.Where(name => _options.Analyses.ContainsKey(name)).ToList();
 
         if (knownNames.Count == 0)
         {

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/AnonymizerResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/AnonymizerResultHandler.cs
@@ -30,32 +30,15 @@ public class AnonymizerResultHandler(
 
         await RewireNextWorkflowIfThermalReading(workflow, result);
 
-        var records = await InspectionRecordResolver.GetInspectionRecords(context, workflow);
+        var inspectionRecord = await InspectionRecordResolver.GetSingleInspectionRecordOrNull(
+            context,
+            workflow,
+            nameof(AnonymizerResultHandler),
+            logger
+        );
 
-        if (records.Count == 0)
-        {
-            logger.LogWarning(
-                "Workflow {WorkflowType} (Id: {WorkflowId}) has no resolvable InspectionRecord — skipping result handling",
-                workflow.WorkflowType,
-                workflow.Id
-            );
+        if (inspectionRecord is null)
             return;
-        }
-
-        if (records.Count > 1)
-        {
-            logger.LogWarning(
-                "Per-record handler '{HandlerType}' invoked on group analysis ({Count} records) — "
-                    + "skipping publish. A group-aware IWorkflowResultHandler must be registered for "
-                    + "'{WorkflowType}' if it runs on group analyses.",
-                nameof(AnonymizerResultHandler),
-                records.Count,
-                workflow.WorkflowType
-            );
-            return;
-        }
-
-        var inspectionRecord = records[0];
 
         if (workflow.OutputBlobStorageLocation is not { } output)
         {

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/CLOEResultHandler.cs
@@ -24,32 +24,16 @@ public class CLOEResultHandler(
 
     public async Task OnWorkflowCompleted(Workflow workflow)
     {
-        var records = await InspectionRecordResolver.GetInspectionRecords(context, workflow);
+        var inspectionRecord = await InspectionRecordResolver.GetSingleInspectionRecordOrNull(
+            context,
+            workflow,
+            nameof(CLOEResultHandler),
+            logger
+        );
 
-        if (records.Count == 0)
-        {
-            logger.LogWarning(
-                "Workflow {WorkflowType} (Id: {WorkflowId}) has no resolvable InspectionRecord — skipping result handling",
-                workflow.WorkflowType,
-                workflow.Id
-            );
+        if (inspectionRecord is null)
             return;
-        }
 
-        if (records.Count > 1)
-        {
-            logger.LogWarning(
-                "Per-record handler '{HandlerType}' invoked on group analysis ({Count} records) — "
-                    + "skipping publish. A group-aware IWorkflowResultHandler must be registered for "
-                    + "'{WorkflowType}' if it runs on group analyses.",
-                nameof(CLOEResultHandler),
-                records.Count,
-                workflow.WorkflowType
-            );
-            return;
-        }
-
-        var inspectionRecord = records[0];
         var result = WorkflowResultHandlerHelpers.DeserializeResult<CLOEResult>(workflow, logger);
 
         var message = new SaraAnalysisResultMessage

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/CopyRawToVisualizedResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/CopyRawToVisualizedResultHandler.cs
@@ -20,32 +20,15 @@ public class CopyRawToVisualizedResultHandler(
 
     public async Task OnWorkflowCompleted(Workflow workflow)
     {
-        var records = await InspectionRecordResolver.GetInspectionRecords(context, workflow);
+        var inspectionRecord = await InspectionRecordResolver.GetSingleInspectionRecordOrNull(
+            context,
+            workflow,
+            nameof(CopyRawToVisualizedResultHandler),
+            logger
+        );
 
-        if (records.Count == 0)
-        {
-            logger.LogWarning(
-                "Workflow {WorkflowType} (Id: {WorkflowId}) has no resolvable InspectionRecord — skipping result handling",
-                workflow.WorkflowType,
-                workflow.Id
-            );
+        if (inspectionRecord is null)
             return;
-        }
-
-        if (records.Count > 1)
-        {
-            logger.LogWarning(
-                "Per-record handler '{HandlerType}' invoked on group analysis ({Count} records) — "
-                    + "skipping publish. A group-aware IWorkflowResultHandler must be registered for "
-                    + "'{WorkflowType}' if it runs on group analyses.",
-                nameof(CopyRawToVisualizedResultHandler),
-                records.Count,
-                workflow.WorkflowType
-            );
-            return;
-        }
-
-        var inspectionRecord = records[0];
 
         if (workflow.OutputBlobStorageLocation is not { } output)
         {

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/CopyRawToVisualizedResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/CopyRawToVisualizedResultHandler.cs
@@ -1,0 +1,72 @@
+using api.Database.Context;
+using api.Database.Models;
+using api.MQTT;
+using api.Utilities;
+
+namespace api.Services.ResultHandlers.WorkflowResultHandlers;
+
+/// <summary>
+/// Publishes visualization_available for the copy-raw-to-visualized passthrough
+/// workflow, which copies a raw inspection blob into the visualization base layer
+/// without running an analyzer.
+/// </summary>
+public class CopyRawToVisualizedResultHandler(
+    SaraDbContext context,
+    IMqttPublisherService mqttPublisherService,
+    ILogger<CopyRawToVisualizedResultHandler> logger
+) : IWorkflowResultHandler
+{
+    public string WorkflowType => "copy-raw-to-visualized";
+
+    public async Task OnWorkflowCompleted(Workflow workflow)
+    {
+        var records = await InspectionRecordResolver.GetInspectionRecords(context, workflow);
+
+        if (records.Count == 0)
+        {
+            logger.LogWarning(
+                "Workflow {WorkflowType} (Id: {WorkflowId}) has no resolvable InspectionRecord — skipping result handling",
+                workflow.WorkflowType,
+                workflow.Id
+            );
+            return;
+        }
+
+        if (records.Count > 1)
+        {
+            logger.LogWarning(
+                "Per-record handler '{HandlerType}' invoked on group analysis ({Count} records) — "
+                    + "skipping publish. A group-aware IWorkflowResultHandler must be registered for "
+                    + "'{WorkflowType}' if it runs on group analyses.",
+                nameof(CopyRawToVisualizedResultHandler),
+                records.Count,
+                workflow.WorkflowType
+            );
+            return;
+        }
+
+        var inspectionRecord = records[0];
+
+        if (workflow.OutputBlobStorageLocation is not { } output)
+        {
+            logger.LogWarning(
+                "copy-raw-to-visualized workflow {WorkflowId} has no OutputBlobStorageLocation — cannot publish visualization_available",
+                workflow.Id
+            );
+            return;
+        }
+
+        var message = new SaraVisualizationAvailableMessage
+        {
+            InspectionId = inspectionRecord.InspectionId,
+            WorkflowId = workflow.Id,
+            AnalysisRunId = workflow.AnalysisRunId,
+            AnalysisId = workflow.AnalysisRun.AnalysisId,
+            StorageAccount = output.StorageAccount,
+            BlobContainer = output.BlobContainer,
+            BlobName = output.BlobName,
+        };
+
+        await mqttPublisherService.PublishSaraVisualizationAvailable(message);
+    }
+}

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/FencillaResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/FencillaResultHandler.cs
@@ -23,32 +23,16 @@ public class FencillaResultHandler(
 
     public async Task OnWorkflowCompleted(Workflow workflow)
     {
-        var records = await InspectionRecordResolver.GetInspectionRecords(context, workflow);
+        var inspectionRecord = await InspectionRecordResolver.GetSingleInspectionRecordOrNull(
+            context,
+            workflow,
+            nameof(FencillaResultHandler),
+            logger
+        );
 
-        if (records.Count == 0)
-        {
-            logger.LogWarning(
-                "Workflow {WorkflowType} (Id: {WorkflowId}) has no resolvable InspectionRecord — skipping result handling",
-                workflow.WorkflowType,
-                workflow.Id
-            );
+        if (inspectionRecord is null)
             return;
-        }
 
-        if (records.Count > 1)
-        {
-            logger.LogWarning(
-                "Per-record handler '{HandlerType}' invoked on group analysis ({Count} records) — "
-                    + "skipping publish. A group-aware IWorkflowResultHandler must be registered for "
-                    + "'{WorkflowType}' if it runs on group analyses.",
-                nameof(FencillaResultHandler),
-                records.Count,
-                workflow.WorkflowType
-            );
-            return;
-        }
-
-        var inspectionRecord = records[0];
         var result = WorkflowResultHandlerHelpers.DeserializeResult<FencillaResult>(
             workflow,
             logger

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/ThermalReadingResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/ThermalReadingResultHandler.cs
@@ -23,32 +23,16 @@ public class ThermalReadingResultHandler(
 
     public async Task OnWorkflowCompleted(Workflow workflow)
     {
-        var records = await InspectionRecordResolver.GetInspectionRecords(context, workflow);
+        var inspectionRecord = await InspectionRecordResolver.GetSingleInspectionRecordOrNull(
+            context,
+            workflow,
+            nameof(ThermalReadingResultHandler),
+            logger
+        );
 
-        if (records.Count == 0)
-        {
-            logger.LogWarning(
-                "Workflow {WorkflowType} (Id: {WorkflowId}) has no resolvable InspectionRecord — skipping result handling",
-                workflow.WorkflowType,
-                workflow.Id
-            );
+        if (inspectionRecord is null)
             return;
-        }
 
-        if (records.Count > 1)
-        {
-            logger.LogWarning(
-                "Per-record handler '{HandlerType}' invoked on group analysis ({Count} records) — "
-                    + "skipping publish. A group-aware IWorkflowResultHandler must be registered for "
-                    + "'{WorkflowType}' if it runs on group analyses.",
-                nameof(ThermalReadingResultHandler),
-                records.Count,
-                workflow.WorkflowType
-            );
-            return;
-        }
-
-        var inspectionRecord = records[0];
         var result = WorkflowResultHandlerHelpers.DeserializeResult<ThermalReadingResult>(
             workflow,
             logger

--- a/api/Services/WorkflowService.cs
+++ b/api/Services/WorkflowService.cs
@@ -118,6 +118,7 @@ public class WorkflowService(
             var payload = new Dictionary<string, object>
             {
                 ["workflowId"] = workflow.Id,
+                ["workflowType"] = workflow.WorkflowType,
                 ["inputBlobStorageLocations"] = workflow.InputBlobStorageLocations,
                 ["outputBlobStorageLocation"] = workflow.OutputBlobStorageLocation,
                 ["extras"] = extras,

--- a/api/Utilities/InspectionRecordResolver.cs
+++ b/api/Utilities/InspectionRecordResolver.cs
@@ -46,4 +46,39 @@ public static class InspectionRecordResolver
         }
         return records.FirstOrDefault();
     }
+
+    public static async Task<InspectionRecord?> GetSingleInspectionRecordOrNull(
+        SaraDbContext context,
+        Workflow workflow,
+        string handlerTypeName,
+        ILogger logger
+    )
+    {
+        var records = await GetInspectionRecords(context, workflow);
+
+        if (records.Count == 0)
+        {
+            logger.LogWarning(
+                "Workflow {WorkflowType} (Id: {WorkflowId}) has no resolvable InspectionRecord — skipping result handling",
+                workflow.WorkflowType,
+                workflow.Id
+            );
+            return null;
+        }
+
+        if (records.Count > 1)
+        {
+            logger.LogWarning(
+                "Per-record handler '{HandlerType}' invoked on group analysis ({Count} records) — "
+                    + "skipping publish. A group-aware IWorkflowResultHandler must be registered for "
+                    + "'{WorkflowType}' if it runs on group analyses.",
+                handlerTypeName,
+                records.Count,
+                workflow.WorkflowType
+            );
+            return null;
+        }
+
+        return records[0];
+    }
 }

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -49,7 +49,8 @@
       "anonymize": { "Workflows": ["anonymizer"] },
       "fencilla": { "Workflows": ["anonymizer", "rain-drop", "fencilla"] },
       "cloe": { "Workflows": ["anonymizer", "rain-drop", "cloe"] },
-      "thermal-reading": { "Workflows": ["anonymizer", "thermal-reading"] }
+      "thermal-reading": { "Workflows": ["anonymizer", "thermal-reading"] },
+      "passthrough": { "Workflows": ["copy-raw-to-visualized"] }
     },
     "Workflows": {
       "anonymizer": {
@@ -80,12 +81,21 @@
         "TriggerUrl": "http://trigger-thermal-reading-source:8080/trigger-thermal-reading",
         "OutputStorageAccount": "saradevstorevis",
         "OutputBlobContainer": ""
+      },
+      "copy-raw-to-visualized": {
+        "TriggerUrl": "http://trigger-utilities-source:8080/trigger-utilities",
+        "OutputStorageAccount": "saradevstoreanon",
+        "OutputBlobContainer": ""
       }
     },
     "DefaultAnalysisByFileExtension": {
       ".jpg": ["anonymize"],
       ".jpeg": ["anonymize"],
       ".png": ["anonymize"]
+    },
+    "DefaultAnalysisByInspectionTypeAndExtension": {
+      "ThermalVideo": { ".mp4": ["passthrough"] },
+      "AcousticMeasurement": { ".mp4": ["passthrough"] }
     },
     "AnalysisGroupTimeoutMinutes": 30
   },


### PR DESCRIPTION
Implements #399: publish `sara/visualization_available` for inspection
records that have no analyzer (e.g. `.mp4` thermal / acoustic video) by
copying the raw blob into the visualization base layer.

- Add `passthrough` analysis + `copy-raw-to-visualized` workflow config,
  plus an inspection-type + extension analysis map (`ThermalVideo` /
  `AcousticMeasurement` `.mp4` -> `passthrough`).
- Resolve analyses by inspection type and extension before falling back
  to the file-extension default.
- Send `workflowType` in the Argo trigger payload so the shared
  `utilities` Sensor can dispatch by operation.
- Add `CopyRawToVisualizedResultHandler` to publish
  visualization-available from the workflow output.
- Rename the `anonymized-location` endpoint to `visualization-location`
  and broaden it to any visualization base-layer workflow (anonymizer or
  copy-raw-to-visualized).

Depends on sara-utilities#1 and analytics-infrastructure#297 (merged). A
follow-up analytics-infrastructure PR wires the Sensor to synthesize
`extras.operation` from `workflowType`, and a flotilla PR switches to the
renamed endpoint.
