### PR TITLE
Fetch inspection record data as sas URL

### DIFF
--- a/api/Controllers/AnalysisController.cs
+++ b/api/Controllers/AnalysisController.cs
@@ -11,27 +11,29 @@ namespace api.Controllers;
 public class AnalysisController(
     ILogger<AnalysisController> logger,
     IAnalysisService analysisService,
-    IAnalysisTriggerService analysisTriggerService
+    IAnalysisTriggerService analysisTriggerService,
+    IBlobStorageService blobStorageService
 ) : ControllerBase
 {
     [HttpGet]
     [Authorize(Roles = Role.Any)]
-    [ProducesResponseType(typeof(PagedResponse<Analysis>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedResponse<AnalysisDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<PagedResponse<Analysis>>> GetAll(
+    public async Task<ActionResult<PagedResponse<AnalysisDto>>> GetAll(
         [FromQuery] AnalysisParameters parameters
     )
     {
         try
         {
             var page = await analysisService.GetAnalyses(parameters);
+            var pageDtos = page.Select((p) => new AnalysisDto(p, blobStorageService)).ToList();
             return Ok(
-                new PagedResponse<Analysis>
+                new PagedResponse<AnalysisDto>
                 {
-                    Items = page,
+                    Items = pageDtos,
                     PageNumber = page.CurrentPage,
                     PageSize = page.PageSize,
                     TotalCount = page.TotalCount,
@@ -54,7 +56,7 @@ public class AnalysisController(
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<Analysis>> GetById([FromRoute] Guid id)
+    public async Task<ActionResult<AnalysisDto>> GetById([FromRoute] Guid id)
     {
         try
         {
@@ -63,7 +65,8 @@ public class AnalysisController(
             {
                 return NotFound($"Could not find analysis with id {id}");
             }
-            return Ok(analysis);
+            var analysisDto = new AnalysisDto(analysis, blobStorageService);
+            return Ok(analysisDto);
         }
         catch (Exception e)
         {

--- a/api/Controllers/InspectionRecordController.cs
+++ b/api/Controllers/InspectionRecordController.cs
@@ -13,7 +13,8 @@ namespace api.Controllers;
 public class InspectionRecordController(
     ILogger<InspectionRecordController> logger,
     IInspectionRecordService inspectionRecordService,
-    IThermalImageService thermalImageService
+    IThermalImageService thermalImageService,
+    IBlobStorageService blobStorageService
 ) : ControllerBase
 {
     // Workflow types whose output forms the visualization base layer for an
@@ -33,17 +34,23 @@ public class InspectionRecordController(
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<PagedResponse<InspectionRecord>>> GetAll(
+    public async Task<ActionResult<PagedResponse<InspectionRecordDto>>> GetAll(
         [FromQuery] InspectionRecordParameters parameters
     )
     {
         try
         {
             var page = await inspectionRecordService.GetInspectionRecords(parameters);
+
+            var pageDtos = page.Select(
+                    (record) => new InspectionRecordDto(record, blobStorageService)
+                )
+                .ToList();
+
             return Ok(
-                new PagedResponse<InspectionRecord>
+                new PagedResponse<InspectionRecordDto>
                 {
-                    Items = page,
+                    Items = pageDtos,
                     PageNumber = page.CurrentPage,
                     PageSize = page.PageSize,
                     TotalCount = page.TotalCount,
@@ -66,7 +73,7 @@ public class InspectionRecordController(
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<InspectionRecord>> GetById([FromRoute] Guid id)
+    public async Task<ActionResult<InspectionRecordDto>> GetById([FromRoute] Guid id)
     {
         try
         {
@@ -75,7 +82,8 @@ public class InspectionRecordController(
             {
                 return NotFound($"Could not find inspection record with id {id}");
             }
-            return Ok(record);
+            var recordDto = new InspectionRecordDto(record, blobStorageService);
+            return Ok(recordDto);
         }
         catch (Exception e)
         {
@@ -92,7 +100,7 @@ public class InspectionRecordController(
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<InspectionRecord>> GetByInspectionId(
+    public async Task<ActionResult<InspectionRecordDto>> GetByInspectionId(
         [FromRoute] string inspectionId
     )
     {
@@ -106,7 +114,8 @@ public class InspectionRecordController(
                     $"Could not find inspection record with inspection id {inspectionId}"
                 );
             }
-            return Ok(record);
+            var recordDto = new InspectionRecordDto(record, blobStorageService);
+            return Ok(recordDto);
         }
         catch (Exception e)
         {

--- a/api/Controllers/Models/AnalysisDto.cs
+++ b/api/Controllers/Models/AnalysisDto.cs
@@ -1,0 +1,45 @@
+#pragma warning disable CS8618
+using api.Database.Models;
+using api.Services;
+
+namespace api.Controllers.Models;
+
+public class AnalysisDto
+{
+    public AnalysisDto(Analysis analysis, IBlobStorageService blobService)
+    {
+        this.Id = analysis.Id;
+        this.Name = analysis.Name;
+        this.CreatedAt = analysis.CreatedAt;
+
+        var workflows = analysis.Runs.SelectMany(r => r.Workflows);
+
+        var anonymizedWorkflow = workflows
+            .Where(w => w.WorkflowType.Equals("anonymizer", StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(w => w.CompletedAt ?? w.StartedAt ?? DateTime.MinValue)
+            .FirstOrDefault();
+        if (anonymizedWorkflow != null && anonymizedWorkflow.OutputBlobStorageLocation != null)
+            this.AnonymizedSAS = blobService
+                .CreateUserDelegationSASUri(anonymizedWorkflow.OutputBlobStorageLocation)
+                .Result;
+
+        var visualizedWorkflow = workflows
+            .Where(w => !w.WorkflowType.Equals("anonymizer", StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(w => w.CompletedAt ?? w.StartedAt ?? DateTime.MinValue)
+            .FirstOrDefault();
+        if (visualizedWorkflow != null && visualizedWorkflow.OutputBlobStorageLocation != null)
+            this.VisualizedSAS = blobService
+                .CreateUserDelegationSASUri(visualizedWorkflow.OutputBlobStorageLocation)
+                .Result;
+    }
+
+    public Guid Id { get; set; }
+
+    public string Name { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public Uri? AnonymizedSAS { get; set; }
+
+    public Uri? VisualizedSAS { get; set; }
+}

--- a/api/Controllers/Models/AnalysisDto.cs
+++ b/api/Controllers/Models/AnalysisDto.cs
@@ -11,6 +11,10 @@ public class AnalysisDto
         this.Id = analysis.Id;
         this.Name = analysis.Name;
         this.CreatedAt = analysis.CreatedAt;
+        this.Runs = analysis.Runs;
+        this.AnalysisGroup = analysis.AnalysisGroup;
+        this.AnalysisGroupId = analysis.AnalysisGroupId;
+        this.InspectionRecords = analysis.InspectionRecords;
 
         var workflows = analysis.Runs.SelectMany(r => r.Workflows);
 
@@ -42,4 +46,12 @@ public class AnalysisDto
     public Uri? AnonymizedSAS { get; set; }
 
     public Uri? VisualizedSAS { get; set; }
+
+    public Guid? AnalysisGroupId { get; set; }
+
+    public AnalysisGroup? AnalysisGroup { get; set; }
+
+    public List<InspectionRecord> InspectionRecords { get; set; }
+
+    public List<AnalysisRun> Runs { get; set; } = [];
 }

--- a/api/Controllers/Models/InspectionRecordDto.cs
+++ b/api/Controllers/Models/InspectionRecordDto.cs
@@ -1,0 +1,24 @@
+using api.Database.Models;
+using api.Services;
+
+namespace api.Controllers.Models;
+
+public class InspectionRecordDto(InspectionRecord record, IBlobStorageService blobService)
+{
+    public Guid Id { get; set; } = record.Id;
+    public string InspectionId { get; set; } = record.InspectionId;
+    public string InstallationCode { get; set; } = record.InstallationCode;
+    public Uri SASToken { get; set; } =
+        blobService.CreateUserDelegationSASUri(record.BlobStorageLocation).Result;
+    public DateTime CreatedAt { get; set; } = record.CreatedAt;
+    public string? InspectionType { get; set; } = record.InspectionType;
+    public string? Tag { get; set; } = record.Tag;
+    public Position? TargetPosition { get; set; } = record.TargetPosition;
+    public Pose? RobotPose { get; set; } = record.RobotPose;
+    public List<AnalysisDto> Analyses { get; set; } =
+    [.. record.Analyses.Select((a) => new AnalysisDto(a, blobService))];
+    public string? InspectionDescription { get; set; } = record.InspectionDescription;
+    public string? RobotName { get; set; } = record.RobotName;
+    public DateTime? Timestamp { get; set; } = record.Timestamp;
+    public Guid? AnalysisGroupId { get; set; } = record.AnalysisGroupId;
+}

--- a/api/Controllers/Models/WorkflowDto.cs
+++ b/api/Controllers/Models/WorkflowDto.cs
@@ -1,0 +1,35 @@
+using api.Database.Models;
+using api.Services;
+
+namespace api.Controllers.Models;
+
+public class WorkflowDto(Workflow workflow, IBlobStorageService blobService)
+{
+    public Guid Id { get; set; } = workflow.Id;
+
+    public int StepNumber { get; set; } = workflow.StepNumber;
+
+    public string WorkflowType { get; set; } = workflow.WorkflowType;
+
+    public List<Uri> InputBlobSAS { get; set; } =
+        workflow
+            .InputBlobStorageLocations.Select(
+                (i) => blobService.CreateUserDelegationSASUri(i).Result
+            )
+            .ToList();
+
+    public WorkflowStatus Status { get; set; } = workflow.Status;
+
+    public Uri? OutputBlobSAS { get; set; } =
+        workflow.OutputBlobStorageLocation != null
+            ? blobService.CreateUserDelegationSASUri(workflow.OutputBlobStorageLocation).Result
+            : null;
+
+    public string? ResultJson { get; set; } = workflow.ResultJson;
+
+    public DateTime? StartedAt { get; set; } = workflow.StartedAt;
+
+    public DateTime? CompletedAt { get; set; } = workflow.CompletedAt;
+
+    public string? ErrorMessage { get; set; } = workflow.ErrorMessage;
+}

--- a/api/Controllers/WorkflowController.cs
+++ b/api/Controllers/WorkflowController.cs
@@ -8,23 +8,27 @@ namespace api.Controllers;
 
 [ApiController]
 [Route("workflow")]
-public class WorkflowController(ILogger<WorkflowController> logger, IWorkflowService service)
-    : ControllerBase
+public class WorkflowController(
+    ILogger<WorkflowController> logger,
+    IWorkflowService service,
+    IBlobStorageService blobService
+) : ControllerBase
 {
     [HttpGet]
     [Authorize(Roles = Role.Any)]
     [ProducesResponseType(typeof(PagedResponse<Workflow>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedResponse<Workflow>>> GetAll(
+    public async Task<ActionResult<PagedResponse<WorkflowDto>>> GetAll(
         [FromQuery] WorkflowParameters parameters
     )
     {
         try
         {
             var page = await service.GetWorkflows(parameters);
+            var pageDtos = page.Select((p) => new WorkflowDto(p, blobService)).ToList();
             return Ok(
-                new PagedResponse<Workflow>
+                new PagedResponse<WorkflowDto>
                 {
-                    Items = page,
+                    Items = pageDtos,
                     PageNumber = page.CurrentPage,
                     PageSize = page.PageSize,
                     TotalCount = page.TotalCount,
@@ -44,14 +48,15 @@ public class WorkflowController(ILogger<WorkflowController> logger, IWorkflowSer
     [Route("id/{id:guid}")]
     [ProducesResponseType(typeof(Workflow), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<Workflow>> GetById([FromRoute] Guid id)
+    public async Task<ActionResult<WorkflowDto>> GetById([FromRoute] Guid id)
     {
         var workflow = await service.ReadById(id);
         if (workflow is null)
         {
             return NotFound($"Could not find workflow with id {id}");
         }
-        return Ok(workflow);
+        var workflowDto = new WorkflowDto(workflow, blobService);
+        return Ok(workflowDto);
     }
 
     [HttpPost]

--- a/api/Services/BlobStorageService.cs
+++ b/api/Services/BlobStorageService.cs
@@ -2,16 +2,16 @@ using api.Database.Models;
 using Azure.Core;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
 
 namespace api.Services;
 
 public interface IBlobStorageService
 {
     Task<MemoryStream> DownloadBlobAsync(BlobStorageLocation location);
-
     Task UploadBlobAsync(BlobStorageLocation destination, Stream content, string contentType);
-
     Task CopyBlobAsync(BlobStorageLocation source, BlobStorageLocation destination);
+    Task<Uri> CreateUserDelegationSASUri(BlobStorageLocation location);
 }
 
 public class BlobStorageService(TokenCredential credential, IConfiguration configuration)
@@ -95,6 +95,36 @@ public class BlobStorageService(TokenCredential credential, IConfiguration confi
         return new BlobServiceClient(
             new Uri($"https://{accountName}.blob.core.windows.net"),
             credential
+        );
+    }
+
+    public async Task<Uri> CreateUserDelegationSASUri(BlobStorageLocation location)
+    {
+        var serviceClient = CreateBlobServiceClient(location.StorageAccount);
+
+        var expiryTime = DateTimeOffset.UtcNow.AddHours(1); // Valid for 1 hour
+
+        var userDelegationKey = await serviceClient.GetUserDelegationKeyAsync(
+            DateTimeOffset.UtcNow,
+            expiryTime
+        );
+
+        BlobSasBuilder sasBuilder = new()
+        {
+            BlobContainerName = location.BlobContainer,
+            BlobName = location.BlobName,
+            Resource = "b",
+            StartsOn = DateTimeOffset.UtcNow,
+            ExpiresOn = expiryTime,
+        };
+
+        sasBuilder.SetPermissions(BlobSasPermissions.Read);
+
+        var sas = sasBuilder
+            .ToSasQueryParameters(userDelegationKey, location.StorageAccount)
+            .ToString();
+        return new Uri(
+            $"https://{location.StorageAccount}.blob.core.windows.net/{location.BlobContainer}/{location.BlobName}?{sas}"
         );
     }
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -99,7 +99,7 @@ export interface InspectionRecord {
   id: string;
   inspectionId: string;
   installationCode: string;
-  blobStorageLocation: BlobStorageLocation;
+  sasToken: string;
   createdAt: string;
   inspectionType?: string | null;
   tag?: string | null;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -112,7 +112,7 @@ export interface InspectionRecord {
   analyses?: Analysis[];
 }
 
-export interface Workflow {
+export interface WorkflowWithoutSAS {
   id: string;
   analysisRunId: string;
   stepNumber: number;
@@ -127,6 +127,21 @@ export interface Workflow {
   analysisRun?: AnalysisRun;
 }
 
+export interface Workflow {
+  id: string;
+  analysisRunId: string;
+  stepNumber: number;
+  workflowType: string;
+  inputBlobSAS: string[];
+  status: WorkflowStatus;
+  outputBlobSAS?: string | null;
+  resultJson?: string | null;
+  startedAt?: string | null;
+  completedAt?: string | null;
+  errorMessage?: string | null;
+  analysisRun?: AnalysisRun;
+}
+
 export interface AnalysisRun {
   id: string;
   analysisId: string;
@@ -134,7 +149,7 @@ export interface AnalysisRun {
   status: AnalysisRunStatus;
   startedAt?: string | null;
   completedAt?: string | null;
-  workflows?: Workflow[];
+  workflows?: WorkflowWithoutSAS[];
   analysis?: Analysis;
 }
 
@@ -142,6 +157,8 @@ export interface Analysis {
   id: string;
   name: string;
   createdAt: string;
+  anonymizedSAS: string;
+  visualizedSAS: string;
   analysisGroupId?: string | null;
   analysisGroup?: AnalysisGroup | null;
   inspectionRecords?: InspectionRecord[];

--- a/frontend/src/pages/analyses/detail.tsx
+++ b/frontend/src/pages/analyses/detail.tsx
@@ -73,6 +73,24 @@ export default function AnalysisDetailPage() {
             <Table.Cell>{analysis.id}</Table.Cell>
           </Table.Row>
           <Table.Row>
+            <Table.Cell>Anonymized data</Table.Cell>
+            <Table.Cell>
+              <Typography link href={analysis.anonymizedSAS}>
+                Link
+              </Typography></Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Visualized data</Table.Cell>
+            <Table.Cell>
+              {
+                analysis.visualizedSAS ? (
+                <Typography link href={analysis.visualizedSAS}>
+                  Link
+                </Typography>) : "-"
+              }
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
             <Table.Cell>Created</Table.Cell>
             <Table.Cell>{new Date(analysis.createdAt).toLocaleString()}</Table.Cell>
           </Table.Row>

--- a/frontend/src/pages/inspection-records/detail.tsx
+++ b/frontend/src/pages/inspection-records/detail.tsx
@@ -8,7 +8,6 @@ import {
 } from "@equinor/eds-core-react";
 import { arrow_back } from "@equinor/eds-icons";
 import { getInspectionRecord, type InspectionRecord, type Orientation, type Position } from "../../api/client";
-import BlobLocation from "../../components/BlobLocation";
 import StatusChip from "../../components/StatusChip";
 
 Icon.add({ arrow_back });
@@ -94,7 +93,12 @@ export default function InspectionRecordDetailPage() {
           <Table.Row>
             <Table.Cell>Blob</Table.Cell>
             <Table.Cell>
-              <BlobLocation loc={record.blobStorageLocation} />
+              {
+                record.sasToken ? (
+                  <Typography link href={record.sasToken}>
+                    Link
+                  </Typography>) : "-"
+              }
             </Table.Cell>
           </Table.Row>
           <Table.Row>

--- a/frontend/src/pages/workflows/detail.tsx
+++ b/frontend/src/pages/workflows/detail.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams } from "react-router";
 import { Button, Icon, Table, Typography } from "@equinor/eds-core-react";
 import { arrow_back } from "@equinor/eds-icons";
 import { getWorkflow, retryWorkflow, type Workflow } from "../../api/client";
-import BlobLocation from "../../components/BlobLocation";
 import StatusChip from "../../components/StatusChip";
 
 Icon.add({ arrow_back });
@@ -110,15 +109,17 @@ export default function WorkflowDetailPage() {
       <Typography variant="h5" style={{ marginBottom: "0.5rem" }}>
         Inputs
       </Typography>
-      {workflow.inputBlobStorageLocations.length === 0 ? (
+      {workflow.inputBlobSAS.length === 0 ? (
         <Typography variant="body_short" style={{ marginBottom: "1.5rem" }}>
           None.
         </Typography>
       ) : (
         <ul style={{ marginBottom: "1.5rem" }}>
-          {workflow.inputBlobStorageLocations.map((loc, i) => (
+          {workflow.inputBlobSAS.map((loc, i) => (
             <li key={i}>
-              <BlobLocation loc={loc} />
+              <Typography link href={loc}>
+                Link
+              </Typography>
             </li>
           ))}
         </ul>
@@ -128,8 +129,10 @@ export default function WorkflowDetailPage() {
         Output
       </Typography>
       <div style={{ marginBottom: "1.5rem" }}>
-        {workflow.outputBlobStorageLocation ? (
-          <BlobLocation loc={workflow.outputBlobStorageLocation} />
+        {workflow.outputBlobSAS ? (
+          <Typography link href={workflow.outputBlobSAS}>
+            Link
+          </Typography>
         ) : (
           <Typography variant="body_short">None.</Typography>
         )}


### PR DESCRIPTION
Closes #419 

To be merged with this PR: https://github.com/equinor/flotilla/pull/2809

Blob data can now be fetched using a URL. Example:

<img width="761" height="926" alt="image" src="https://github.com/user-attachments/assets/56125cd8-f49c-4255-92a7-be9dce21303d" />

## Ready for review checklist:

- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.
