### PR TITLE
Remove System.Security.Cryptography.Xml from api.csproj

### DIFF
--- a/api/api.csproj
+++ b/api/api.csproj
@@ -5,8 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--disable missing comment warning-->
-    <!-- disable NU1510 temporary to handle vulnerabilities -->
-    <NoWarn>$(NoWarn);1591;NU1510</NoWarn>
+    <NoWarn>$(NoWarn);1591</NoWarn>
     <UserSecretsId>2febe2ef-3c95-4e60-925e-85e1fdba53cf</UserSecretsId>
   </PropertyGroup>
 
@@ -54,8 +53,6 @@
       (CVE-2026-49451 / GHSA-v5pm-xwqc-g5wc).
     -->
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
-    <!-- Pin Kiota.Abstractions to the patched version until Graph updates transitively. -->
     <!--
       Pin SQLitePCLRaw.bundle_e_sqlite3 to the 3.x line so the native SQLite library is
       sourced from SourceGear.sqlite3 (SQLite >= 3.50.4) instead of the deprecated and


### PR DESCRIPTION
## Summary
- Removes the explicit `System.Security.Cryptography.Xml` 10.0.7 package reference from `api/api.csproj`. It was originally added to force-update a vulnerable transitive version, but is no longer needed: the package is not referenced anywhere in the codebase, and no vulnerable transitive dependency reappears after removal. (Version 10.0.7 itself is now flagged with 4 High-severity advisories.)
- Drops `NU1510` from `NoWarn` since the workaround it covered is gone.

## Verification
- `dotnet restore` + `dotnet build` succeed with 0 warnings, 0 errors.
- `dotnet list package --include-transitive --vulnerable` reports no vulnerable packages.

## Note on other pins
- `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 was also reviewed — it is still required. Removing it causes NuGet to resolve the vulnerable transitive `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (GHSA-2m69-gcr7-jv3q), so the pin stays.

Closes #300