### PR TITLE
Add Flotilla mission deep-link to inspection records

### DIFF
--- a/api.Tests/Controllers/DashboardControllerTests.cs
+++ b/api.Tests/Controllers/DashboardControllerTests.cs
@@ -84,11 +84,35 @@ public class DashboardControllerTests : IAsyncLifetime
         var run = await _db.NewAnalysisRun(analysis);
 
         // In window (last 24h)
-        await SeedWorkflow(run, "fencilla", WorkflowStatus.Succeeded, now.AddHours(-2), now.AddHours(-1));
-        await SeedWorkflow(run, "fencilla", WorkflowStatus.Failed, now.AddHours(-3), now.AddHours(-2));
-        await SeedWorkflow(run, "cloe", WorkflowStatus.Succeeded, now.AddHours(-5), now.AddHours(-4));
+        await SeedWorkflow(
+            run,
+            "fencilla",
+            WorkflowStatus.Succeeded,
+            now.AddHours(-2),
+            now.AddHours(-1)
+        );
+        await SeedWorkflow(
+            run,
+            "fencilla",
+            WorkflowStatus.Failed,
+            now.AddHours(-3),
+            now.AddHours(-2)
+        );
+        await SeedWorkflow(
+            run,
+            "cloe",
+            WorkflowStatus.Succeeded,
+            now.AddHours(-5),
+            now.AddHours(-4)
+        );
         // Out of window
-        await SeedWorkflow(run, "fencilla", WorkflowStatus.Succeeded, now.AddHours(-40), now.AddHours(-39));
+        await SeedWorkflow(
+            run,
+            "fencilla",
+            WorkflowStatus.Succeeded,
+            now.AddHours(-40),
+            now.AddHours(-39)
+        );
 
         var summary = await GetSummary(24);
 

--- a/api/Controllers/Models/InspectionRecordDto.cs
+++ b/api/Controllers/Models/InspectionRecordDto.cs
@@ -7,6 +7,7 @@ public class InspectionRecordDto(InspectionRecord record, IBlobStorageService bl
 {
     public Guid Id { get; set; } = record.Id;
     public string InspectionId { get; set; } = record.InspectionId;
+    public string? FlotillaMissionId { get; set; } = record.FlotillaMissionId;
     public string InstallationCode { get; set; } = record.InstallationCode;
     public BlobStorageLocation BlobStorageLocation { get; set; } = record.BlobStorageLocation;
     public DateTime CreatedAt { get; set; } = record.CreatedAt;

--- a/api/Database/Models/InspectionRecord.cs
+++ b/api/Database/Models/InspectionRecord.cs
@@ -13,6 +13,8 @@ public class InspectionRecord
     [Required]
     public required string InspectionId { get; set; }
 
+    public string? FlotillaMissionId { get; set; }
+
     [Required]
     public required string InstallationCode { get; set; }
 

--- a/api/MQTT/IsarInspectionResult.cs
+++ b/api/MQTT/IsarInspectionResult.cs
@@ -34,6 +34,9 @@ public class IsarInspectionResultMessage : MqttMessage
     [Required]
     public required string InspectionId { get; set; }
 
+    [JsonPropertyName("mission_id")]
+    public string? MissionId { get; set; }
+
     [JsonPropertyName("blob_storage_data_path")]
     [Required]
     public required InspectionPathMessage InspectionDataPath { get; set; }

--- a/api/Migrations/20260730121442_AddFlotillaMissionIdToInspectionRecord.Designer.cs
+++ b/api/Migrations/20260730121442_AddFlotillaMissionIdToInspectionRecord.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using api.Database.Context;
@@ -11,9 +12,11 @@ using api.Database.Context;
 namespace api.Migrations
 {
     [DbContext(typeof(SaraDbContext))]
-    partial class SaraDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260730121442_AddFlotillaMissionIdToInspectionRecord")]
+    partial class AddFlotillaMissionIdToInspectionRecord
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20260730121442_AddFlotillaMissionIdToInspectionRecord.cs
+++ b/api/Migrations/20260730121442_AddFlotillaMissionIdToInspectionRecord.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFlotillaMissionIdToInspectionRecord : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FlotillaMissionId",
+                table: "InspectionRecords",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FlotillaMissionId",
+                table: "InspectionRecords");
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -213,6 +213,7 @@ app.MapGet(
                     TenantId = configuration["AzureAd:TenantId"] ?? "",
                 },
                 BasePath = (configuration["ApiBaseRoute"] ?? "").TrimEnd('/'),
+                FlotillaBaseUrl = (configuration["FlotillaBaseUrl"] ?? "").TrimEnd('/'),
             }
     )
     .AllowAnonymous();

--- a/api/Services/InspectionRecordService.cs
+++ b/api/Services/InspectionRecordService.cs
@@ -92,6 +92,9 @@ public class InspectionRecordService(
         var inspectionRecord = new InspectionRecord
         {
             InspectionId = inspectionId,
+            FlotillaMissionId = message.MissionId is null
+                ? null
+                : Sanitize.SanitizeUserInput(message.MissionId),
             InstallationCode = Sanitize.SanitizeUserInput(message.InstallationCode),
             BlobStorageLocation = new BlobStorageLocation
             {

--- a/api/appsettings.Local.json
+++ b/api/appsettings.Local.json
@@ -36,6 +36,7 @@
     "DevUserId": ""
   },
   "SARATimeseriesBaseUrl": "",
+  "FlotillaBaseUrl": "http://localhost:3001",
   "OpenTelemetry": {
     "Enabled": true,
     "OtelExporterOtlpEndpoint": "http://localhost:4318",

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -29,6 +29,7 @@
     "UseKeyVault": true
   },
   "ApiBaseRoute": "",
+  "FlotillaBaseUrl": "",
   "Frontend": {
     "Enabled": true
   },

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -104,6 +104,7 @@ export interface AnalysisGroupRef {
 export interface InspectionRecord {
   id: string;
   inspectionId: string;
+  flotillaMissionId?: string | null;
   installationCode: string;
   blobStorageLocation: BlobStorageLocation;
   createdAt: string;

--- a/frontend/src/authConfig.ts
+++ b/frontend/src/authConfig.ts
@@ -4,23 +4,37 @@ export interface AppConfig {
   clientId: string;
   tenantId: string;
   basePath: string;
+  flotillaBaseUrl: string;
 }
 
-let appConfig: AppConfig = { clientId: "", tenantId: "", basePath: "" };
+let appConfig: AppConfig = {
+  clientId: "",
+  tenantId: "",
+  basePath: "",
+  flotillaBaseUrl: "",
+};
 
 export function getAppConfig(): AppConfig {
   return appConfig;
 }
 
+// Resolve the config endpoint against the app's base (where the bundle lives),
+// not the current route. With Vite's relative base the bundle is served from
+// `{basePath}/assets/*.js`, so "../api/config" always resolves to
+// `{basePath}/api/config` in dev and any deployed sub-path. Using a route-relative
+// URL instead breaks on deep links/refreshes (e.g. /inspection-records/:id).
+const configUrl = new URL(/* @vite-ignore */ "../api/config", import.meta.url);
+
 export async function loadAppConfig(): Promise<AppConfig> {
   try {
-    const res = await fetch("api/config");
+    const res = await fetch(configUrl);
     if (res.ok) {
       const data = await res.json();
       appConfig = {
         clientId: data.azureAd?.clientId ?? "",
         tenantId: data.azureAd?.tenantId ?? "",
         basePath: data.basePath ?? "",
+        flotillaBaseUrl: data.flotillaBaseUrl ?? "",
       };
     }
   } catch {
@@ -29,6 +43,7 @@ export async function loadAppConfig(): Promise<AppConfig> {
       clientId: import.meta.env.VITE_AZURE_AD_CLIENT_ID ?? "",
       tenantId: import.meta.env.VITE_AZURE_AD_TENANT_ID ?? "",
       basePath: "",
+      flotillaBaseUrl: "",
     };
   }
   return appConfig;

--- a/frontend/src/pages/inspection-records/detail.tsx
+++ b/frontend/src/pages/inspection-records/detail.tsx
@@ -6,14 +6,35 @@ import {
   Table,
   Typography,
 } from "@equinor/eds-core-react";
-import { arrow_back } from "@equinor/eds-icons";
+import { arrow_back, external_link } from "@equinor/eds-icons";
 import { getInspectionRecord, type InspectionRecord, type Orientation, type Position } from "../../api/client";
+import { getAppConfig } from "../../authConfig";
 import StatusChip from "../../components/StatusChip";
 import BlobLocation from "../../components/BlobLocation";
 
-Icon.add({ arrow_back });
+Icon.add({ arrow_back, external_link });
 
 const fmt = (n: number) => n.toFixed(3);
+
+function flotillaMissionUrl(
+  installationCode: string | null | undefined,
+  inspectionId: string | null | undefined,
+  flotillaMissionId: string | null | undefined
+): string | null {
+  const base = getAppConfig().flotillaBaseUrl;
+  if (!base || !installationCode) return null;
+  // Prefer linking to the mission run page (resolves by Flotilla mission id),
+  // highlighting the specific inspection via the query param when available.
+  if (flotillaMissionId) {
+    const url = `${base}/${encodeURIComponent(installationCode)}/mission/${encodeURIComponent(flotillaMissionId)}`;
+    return inspectionId
+      ? `${url}?inspectionId=${encodeURIComponent(inspectionId)}`
+      : url;
+  }
+  // Fallback for older records without a mission id: the inspection-only route.
+  if (!inspectionId) return null;
+  return `${base}/${encodeURIComponent(installationCode)}/mission-simple?inspectionId=${encodeURIComponent(inspectionId)}`;
+}
 
 function formatPosition(p: Position | null | undefined): string {
   if (!p) return "–";
@@ -46,6 +67,8 @@ export default function InspectionRecordDetailPage() {
     );
   if (!record) return <Typography variant="body_short">Loading…</Typography>;
 
+  const flotillaUrl = flotillaMissionUrl(record.installationCode, record.inspectionId, record.flotillaMissionId);
+
   return (
     <div style={{ paddingTop: "1rem" }}>
       <Button variant="ghost" onClick={() => navigate(-1)}>
@@ -65,6 +88,22 @@ export default function InspectionRecordDetailPage() {
             <Table.Cell>Installation</Table.Cell>
             <Table.Cell>{record.installationCode}</Table.Cell>
           </Table.Row>
+          {flotillaUrl && (
+            <Table.Row>
+              <Table.Cell>Flotilla</Table.Cell>
+              <Table.Cell>
+                <Button
+                  variant="ghost"
+                  href={flotillaUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View mission in Flotilla
+                  <Icon name="external_link" />
+                </Button>
+              </Table.Cell>
+            </Table.Row>
+          )}
           <Table.Row>
             <Table.Cell>Tag</Table.Cell>
             <Table.Cell>{record.tag ?? "–"}</Table.Cell>


### PR DESCRIPTION
## Summary
Adds a deep link from a SARA inspection record to the corresponding Flotilla mission page.

- Store the Flotilla mission id forwarded by ISAR on the `inspection_result` MQTT topic (`IsarInspectionResult.MissionId` → `InspectionRecord.FlotillaMissionId`, new nullable column + migration).
- Expose `flotillaMissionId` via the inspection-record DTO/API client.
- Build the link `{FlotillaBaseUrl}/{installationCode}/mission/{flotillaMissionId}?inspectionId={inspectionId}` on the inspection-record detail page; records without a stored mission id fall back to the existing `mission-simple?inspectionId=` link.
- Add `FlotillaBaseUrl` config (Program.cs `/api/config`, appsettings).

## Config-load fix (folded in)
Resolve the frontend `/api/config` fetch against the app base (`import.meta.url`) instead of the current route, so deep links and refreshes (e.g. `/inspection-records/:id`) load config correctly.

## Dependency
Populating `FlotillaMissionId` on **new** records requires the matching ISAR change that forwards `mission_id` on the `inspection_result` topic (separate PR against equinor/isar). Existing records and robots without that change gracefully fall back to the simple link.

## Verification
- `dotnet build api`: 0 warnings / 0 errors
- `frontend`: `tsc --noEmit` clean