### PR TITLE
Remove unused inputBlobSAS from Workflow frontend

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -138,7 +138,6 @@ export interface Workflow {
   analysisRunId: string;
   stepNumber: number;
   workflowType: string;
-  inputBlobSAS: string[];
   status: WorkflowStatus;
   outputBlobSAS?: string | null;
   resultJson?: string | null;

--- a/frontend/src/pages/workflows/detail.tsx
+++ b/frontend/src/pages/workflows/detail.tsx
@@ -107,25 +107,6 @@ export default function WorkflowDetailPage() {
       </Table>
 
       <Typography variant="h5" style={{ marginBottom: "0.5rem" }}>
-        Inputs
-      </Typography>
-      {workflow.inputBlobSAS.length === 0 ? (
-        <Typography variant="body_short" style={{ marginBottom: "1.5rem" }}>
-          None.
-        </Typography>
-      ) : (
-        <ul style={{ marginBottom: "1.5rem" }}>
-          {workflow.inputBlobSAS.map((loc, i) => (
-            <li key={i}>
-              <Typography link href={loc}>
-                Link
-              </Typography>
-            </li>
-          ))}
-        </ul>
-      )}
-
-      <Typography variant="h5" style={{ marginBottom: "0.5rem" }}>
         Output
       </Typography>
       <div style={{ marginBottom: "1.5rem" }}>


### PR DESCRIPTION
## Summary
The `inputBlobSAS` field on the workflow is no longer used by the frontend.

- Remove `inputBlobSAS` from the `Workflow` API type.
- Remove the dead "Inputs" section from the workflow detail page.

## Verification
- `frontend`: `tsc --noEmit` clean
- No remaining `inputBlobSAS` references in `frontend/`