### PR TITLE
MQTT: Include output blob location in visualization_available payload

### DIFF
--- a/api/MQTT/IsarInspectionResult.cs
+++ b/api/MQTT/IsarInspectionResult.cs
@@ -106,6 +106,15 @@ public class SaraVisualizationAvailableMessage : MqttMessage
 
     [JsonPropertyName("analysis_id")]
     public required Guid AnalysisId { get; set; }
+
+    [JsonPropertyName("storageAccount")]
+    public required string StorageAccount { get; set; }
+
+    [JsonPropertyName("blobContainer")]
+    public required string BlobContainer { get; set; }
+
+    [JsonPropertyName("blobName")]
+    public required string BlobName { get; set; }
 }
 
 public class SaraAnalysisResultMessage : MqttMessage

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/AnonymizerResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/AnonymizerResultHandler.cs
@@ -55,6 +55,9 @@ public class AnonymizerResultHandler(
             WorkflowId = workflow.Id,
             AnalysisRunId = workflow.AnalysisRunId,
             AnalysisId = workflow.AnalysisRun.AnalysisId,
+            StorageAccount = output.StorageAccount,
+            BlobContainer = output.BlobContainer,
+            BlobName = output.BlobName,
         };
 
         await mqttPublisherService.PublishSaraVisualizationAvailable(message);

--- a/api/Services/ResultHandlers/WorkflowResultHandlers/CopyRawToVisualizedResultHandler.cs
+++ b/api/Services/ResultHandlers/WorkflowResultHandlers/CopyRawToVisualizedResultHandler.cs
@@ -45,6 +45,9 @@ public class CopyRawToVisualizedResultHandler(
             WorkflowId = workflow.Id,
             AnalysisRunId = workflow.AnalysisRunId,
             AnalysisId = workflow.AnalysisRun.AnalysisId,
+            StorageAccount = output.StorageAccount,
+            BlobContainer = output.BlobContainer,
+            BlobName = output.BlobName,
         };
 
         await mqttPublisherService.PublishSaraVisualizationAvailable(message);


### PR DESCRIPTION
## Summary
- Add `storageAccount`, `blobContainer`, and `blobName` fields to `SaraVisualizationAvailableMessage` and populate them from `workflow.OutputBlobStorageLocation` in the anonymizer and copy-raw-to-visualized result handlers.
- Aligns the published payload with the Flotilla backend's `SaraInspectionResultMessage` contract, which declares these three fields as `required`. Without them `System.Text.Json` throws on deserialization and the backend silently drops every `sara/visualization_available` message, so inspection visualizations never surface in the frontend.

## Verification
- `dotnet build sara.sln` clean.
- Observed on aks-staging: SARA publishes viz messages, broker forwards to backend, backend logs nothing — matches the deserialization-failure hypothesis.