### PR TITLE
Select the identity provider by configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,60 @@ Use `Local` for normal day-to-day development. Use `Development` when
 you need behaviour identical to the deployed dev pod (real Postgres,
 real OpenTelemetry export, etc.).
 
+- **Keycloak (no Azure sign-in)** — both options above require Azure
+  credentials to *authenticate*: `Local` needs `az login` to reach
+  `saradev-kv`, and `Development` needs a client secret from it. Setting
+  `Authentication:Provider` to `Oidc` points token validation at any
+  conformant OpenID Connect issuer instead.
+
+  ```bash
+  docker compose --profile keycloak up keycloak
+  ```
+
+  This starts Keycloak on `http://localhost:8080` and imports the same
+  realm the armada integration tests use, so a local run and a CI run
+  exercise the same clients, scopes and roles. The realm is read from
+  `../armada/robotics_integration_tests/custom_realms`; set
+  `KEYCLOAK_REALM_DIR` if armada is not checked out beside this
+  repository.
+
+  Then add to `api/.env`:
+
+  ```
+  Authentication__Provider=Oidc
+  AzureAd__Authority=http://localhost:8080/realms/robotics
+  AzureAd__ClientId=sara-test
+  AzureAd__AllowedAuthMethods__0=WorkloadIdentity
+  KeyVault__UseKeyVault=false
+  Database__UseInMemoryDatabase=true
+  ```
+
+  A token for calling the API directly, or from Swagger:
+
+  ```bash
+  curl -s -X POST http://localhost:8080/realms/robotics/protocol/openid-connect/token \
+    -d grant_type=client_credentials \
+    -d client_id=integration-tests \
+    -d client_secret=integration-tests-secret \
+    -d scope=sara-api | jq -r .access_token
+  ```
+
+  `Authentication:Provider` is not a way to switch authentication off:
+  issuer, audience, signature, lifetime and roles are validated under
+  either value. It also cannot weaken transport security — an `http://`
+  authority is accepted only in the `Local` and `IntegrationTest`
+  environments and fails at startup anywhere else.
+
+  Note what this does *not* remove. `AzureAd:AllowedAuthMethods` governs
+  a separate concern: the `TokenCredential` the API uses for blob
+  storage and Microsoft Graph. `AzureCliBootstrap` and `ClientSecret`
+  both need Azure credentials at startup, so the setting above selects
+  `WorkloadIdentity`, which is constructed lazily and therefore does not
+  throw outside AKS — but any code path that actually reaches blob
+  storage or e-mail will still fail. Only sign-in is covered here, not
+  the API's other Azure dependencies. The frontend also still signs in
+  against Entra ID.
+
 
 ## Test & format
 

--- a/api.Tests/AuthenticationConfigurationsTests.cs
+++ b/api.Tests/AuthenticationConfigurationsTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using api.Configurations;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Api.Test;
+
+/// <summary>
+/// Guard rails for the generic OpenID Connect authentication path.
+///
+/// The path is selected by Authentication:Provider, so unlike an environment name it
+/// is reachable anywhere -- deliberately, because local development and deployments
+/// outside Azure both need it. These tests therefore assert two separate things: that
+/// Entra ID remains the default and its issuer validator is left intact, and that an
+/// unencrypted issuer is refused outside the two environments where the issuer is
+/// necessarily local.
+/// </summary>
+public class AuthenticationConfigurationsTests
+{
+    private const string KeycloakAuthority = "http://keycloak:8080/realms/robotics";
+
+    private sealed class StubHostEnvironment(string environmentName) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = environmentName;
+        public string ApplicationName { get; set; } = "Api.Test";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+
+    private static ServiceProvider BuildProvider(
+        string environmentName,
+        string? provider = null,
+        string? authority = null
+    )
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["AzureAd:Instance"] = "https://login.microsoftonline.com",
+            ["AzureAd:TenantId"] = "00000000-0000-0000-0000-000000000000",
+            ["AzureAd:ClientId"] = "sara-test",
+        };
+
+        if (provider is not null)
+        {
+            settings[AuthenticationConfigurations.ProviderKey] = provider;
+        }
+
+        if (authority is not null)
+        {
+            settings["AzureAd:Authority"] = authority;
+        }
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.ConfigureAuthentication(configuration, new StubHostEnvironment(environmentName));
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ServiceProvider BuildOidcProvider(
+        string environmentName,
+        string authority = KeycloakAuthority
+    ) => BuildProvider(environmentName, AuthenticationConfigurations.OidcProvider, authority);
+
+    private static JwtBearerOptions GetJwtBearerOptions(ServiceProvider provider) =>
+        provider
+            .GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+            .Get(JwtBearerDefaults.AuthenticationScheme);
+
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Staging")]
+    [InlineData("Production")]
+    [InlineData("Local")]
+    [InlineData("Test")]
+    [InlineData(AuthenticationConfigurations.IntegrationTestEnvironment)]
+    public void EntraIssuerValidatorSurvivesUnderTheDefaultProvider(string environmentName)
+    {
+        using var provider = BuildProvider(environmentName);
+
+        var options = GetJwtBearerOptions(provider);
+
+        // AddMicrosoftIdentityWebApi installs the Entra-aware issuer validator. If this
+        // is ever null while the provider is EntraId, issuer validation has been
+        // weakened for a real deployment.
+        Assert.NotNull(options.TokenValidationParameters.IssuerValidator);
+    }
+
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Staging")]
+    [InlineData("Production")]
+    [InlineData("Local")]
+    [InlineData(AuthenticationConfigurations.IntegrationTestEnvironment)]
+    public void AuthorityIsNotRedirectedUnderTheDefaultProvider(string environmentName)
+    {
+        using var provider = BuildProvider(environmentName);
+
+        var options = GetJwtBearerOptions(provider);
+
+        Assert.DoesNotContain("keycloak", options.Authority ?? string.Empty);
+    }
+
+    [Theory]
+    [InlineData("Local")]
+    [InlineData(AuthenticationConfigurations.IntegrationTestEnvironment)]
+    public void OidcProviderRedirectsTokenValidation(string environmentName)
+    {
+        using var provider = BuildOidcProvider(environmentName);
+
+        var options = GetJwtBearerOptions(provider);
+
+        Assert.Equal(KeycloakAuthority, options.Authority);
+        Assert.Equal("sara-test", options.Audience);
+        Assert.False(options.RequireHttpsMetadata);
+
+        var parameters = options.TokenValidationParameters;
+        Assert.True(parameters.ValidateIssuer);
+        Assert.True(parameters.ValidateAudience);
+        Assert.True(parameters.ValidateLifetime);
+        // The Entra-specific validator must be gone, otherwise the issuer would be
+        // rejected and instance discovery would hit login.microsoftonline.com.
+        Assert.Null(parameters.IssuerValidator);
+    }
+
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Staging")]
+    [InlineData("Production")]
+    [InlineData("Test")]
+    public void UnencryptedIssuerIsRefusedInDeployedEnvironments(string environmentName)
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            BuildOidcProvider(environmentName)
+        );
+
+        Assert.Contains("must use HTTPS", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Staging")]
+    [InlineData("Production")]
+    public void EncryptedIssuerIsAcceptedInDeployedEnvironments(string environmentName)
+    {
+        using var provider = BuildOidcProvider(
+            environmentName,
+            "https://keycloak.example.com/realms/robotics"
+        );
+
+        var options = GetJwtBearerOptions(provider);
+
+        // Metadata over HTTPS is required, which is the whole point of the rail.
+        Assert.True(options.RequireHttpsMetadata);
+        Assert.Null(options.TokenValidationParameters.IssuerValidator);
+    }
+
+    [Fact]
+    public void OidcProviderWithoutAnAuthorityFailsLoudly()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            BuildProvider("Local", AuthenticationConfigurations.OidcProvider, authority: null)
+        );
+
+        Assert.Contains("AzureAd:Authority is required", exception.Message);
+    }
+}

--- a/api.Tests/Security/ProtectedEndpointsTests.cs
+++ b/api.Tests/Security/ProtectedEndpointsTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Test.Security;
+
+/// <summary>
+/// Asserts that every endpoint is protected, and that unauthenticated requests
+/// are actually rejected at runtime.
+///
+/// SARA relies on a global fallback policy plus <c>[Authorize]</c> on each
+/// action, and until now nothing verified either. Mirrors the equivalent suite in
+/// equinor/flotilla. Keeping this here rather than in the armada integration
+/// tests means every endpoint is covered, for the cost of one PostgreSQL
+/// container instead of a whole robot fleet.
+/// </summary>
+public class ProtectedEndpointsTests : IAsyncLifetime
+{
+    public required HttpClient Client;
+    public required EndpointDataSource DataSource;
+
+    public async ValueTask InitializeAsync()
+    {
+        (_, string connectionString) = await TestSetupHelpers.ConfigurePostgreSqlDatabase();
+
+        var factory = TestSetupHelpers.ConfigureUnauthenticatedWebApplicationFactory(
+            connectionString
+        );
+
+        Client = TestSetupHelpers.ConfigureUnauthenticatedHttpClient(factory);
+
+        using var scope = factory.Services.CreateScope();
+        DataSource = scope.ServiceProvider.GetRequiredService<EndpointDataSource>();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        return ValueTask.CompletedTask;
+    }
+
+    private static string ReplaceRouteParamsWithDefaults(string route)
+    {
+        return route
+            .Replace("{id}", "1")
+            .Replace("{workflowId}", "1")
+            .Replace("{analysisId}", "1")
+            .Replace("{analysisRunId}", "1")
+            .Replace("{analysisGroupId}", "1")
+            .Replace("{inspectionId}", "1")
+            .Replace("{installationCode}", "TEST")
+            .Replace("{*path}", "test")
+            .Replace("{**slug}", "test")
+            .Replace("{", "")
+            .Replace("}", "");
+    }
+
+    private IEnumerable<(string, string)> GetProtectedRoutes()
+    {
+        var routes = new List<(string, string)>();
+
+        foreach (var endpoint in DataSource.Endpoints.OfType<RouteEndpoint>())
+        {
+            var metadata = endpoint.Metadata;
+
+            if (metadata.OfType<IAllowAnonymous>().Any())
+                continue;
+
+            var methods = metadata.OfType<HttpMethodMetadata>().FirstOrDefault()?.HttpMethods ?? [];
+            var route = endpoint.RoutePattern.RawText ?? string.Empty;
+            var path = ReplaceRouteParamsWithDefaults(route);
+
+            foreach (var method in methods)
+                routes.Add((method.ToUpperInvariant(), path));
+        }
+
+        return routes.Distinct();
+    }
+
+    [Fact]
+    public void AllEndpointsShouldRequireAuthorization()
+    {
+        foreach (var endpoint in DataSource.Endpoints.OfType<RouteEndpoint>())
+        {
+            var metadata = endpoint.Metadata;
+            var hasAllowAnonymous = metadata.OfType<IAllowAnonymous>().Any();
+            var hasAuthorize = metadata.OfType<IAuthorizeData>().Any();
+
+            var route = endpoint.RoutePattern.RawText ?? "UNKNOWN";
+            var isWhitelisted = route.Contains("health") || route.Contains("swagger");
+
+            if (!hasAuthorize && !hasAllowAnonymous && !isWhitelisted)
+                Assert.Fail(
+                    $"Endpoint '{route}' is not protected with [Authorize] or [AllowAnonymous]"
+                );
+        }
+    }
+
+    [Fact]
+    public async Task EndpointsShouldReturn401Or403ForUnauthenticatedRequests()
+    {
+        var testRoutes = GetProtectedRoutes();
+
+        Assert.NotEmpty(testRoutes);
+
+        foreach (var (method, url) in testRoutes)
+        {
+            var request = new HttpRequestMessage(new HttpMethod(method), url);
+            var response = await Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+            Assert.True(
+                response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized,
+                $"Expected 401/403 for {method} {url}, but got {response.StatusCode}"
+            );
+        }
+    }
+}

--- a/api.Tests/TestSetupHelpers.cs
+++ b/api.Tests/TestSetupHelpers.cs
@@ -60,6 +60,36 @@ public static class TestSetupHelpers
         return new TestWebApplicationFactory<Program>(postgresConnectionString);
     }
 
+    /// <summary>
+    /// A factory that keeps the real authentication stack in place, so that
+    /// requests without a token are rejected as they would be in a deployment.
+    /// </summary>
+    public static TestWebApplicationFactory<Program> ConfigureUnauthenticatedWebApplicationFactory(
+        string postgresConnectionString
+    )
+    {
+        return new TestWebApplicationFactory<Program>(
+            postgresConnectionString,
+            replaceAuthentication: false
+        );
+    }
+
+    /// <summary>
+    /// An HTTP client that sends no credentials at all.
+    /// </summary>
+    public static HttpClient ConfigureUnauthenticatedHttpClient(
+        TestWebApplicationFactory<Program> factory
+    )
+    {
+        return factory.CreateClient(
+            new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                BaseAddress = new Uri("http://localhost:8000"),
+            }
+        );
+    }
+
     public static HttpClient ConfigureHttpClient(TestWebApplicationFactory<Program> factory)
     {
         var client = factory.CreateClient(

--- a/api.Tests/TestWebApplicationFactory.cs
+++ b/api.Tests/TestWebApplicationFactory.cs
@@ -26,11 +26,21 @@ namespace Api.Test;
 /// the named "Argo" HttpClient onto a recording handler, and removes background
 /// hosted services so the test host does not connect to a real broker.
 /// </summary>
-public class TestWebApplicationFactory<TProgram>(string postgresConnectionString)
-    : WebApplicationFactory<Program>
+public class TestWebApplicationFactory<TProgram>(
+    string postgresConnectionString,
+    bool replaceAuthentication = true
+) : WebApplicationFactory<Program>
     where TProgram : class
 {
     private readonly string _postgresConnectionString = postgresConnectionString;
+
+    /// <summary>
+    /// When false, the real JWT bearer authentication stays in place instead of
+    /// being swapped for <see cref="TestAuthHandler"/>. Used to assert that
+    /// endpoints actually reject unauthenticated callers; every other test wants
+    /// the stub handler.
+    /// </summary>
+    private readonly bool _replaceAuthentication = replaceAuthentication;
 
     public RecordingMqttPublisher MqttPublisher { get; } = new();
     public RecordingHttpMessageHandler ArgoHttpHandler { get; } = new();
@@ -75,7 +85,10 @@ public class TestWebApplicationFactory<TProgram>(string postgresConnectionString
             ReplaceArgoHttpClient(services);
             ReplaceEmailService(services);
             ReplaceTimeseriesService(services);
-            ReplaceAuthentication(services);
+            if (_replaceAuthentication)
+            {
+                ReplaceAuthentication(services);
+            }
             RegisterMqttEventHandler(services);
             RemoveHostedServices(services);
             ReplaceBlobStorageService(services);

--- a/api/Configurations/AuthenticationConfigurations.cs
+++ b/api/Configurations/AuthenticationConfigurations.cs
@@ -1,0 +1,151 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Identity.Web;
+
+namespace api.Configurations
+{
+    public static class AuthenticationConfigurations
+    {
+        /// <summary>
+        /// Selects which identity provider the API authenticates against.
+        ///
+        /// <c>EntraId</c> (the default) is Microsoft Entra ID, unchanged.
+        /// <c>Oidc</c> is any conformant OpenID Connect issuer -- a Keycloak realm for
+        /// local development and for the armada integration tests, and in principle an
+        /// operator's own issuer for a deployment outside Azure.
+        ///
+        /// This is not an authentication bypass. Issuer, audience, signature, lifetime
+        /// and role validation all remain enabled; only the issuer differs. What is
+        /// gated instead is transport security, by <see cref="AllowsInsecureMetadata"/>.
+        /// </summary>
+        public const string ProviderKey = "Authentication:Provider";
+        public const string EntraIdProvider = "EntraId";
+        public const string OidcProvider = "Oidc";
+
+        /// <summary>
+        /// The environment used by the armada integration tests. Selects
+        /// appsettings.IntegrationTest.json, which turns off Key Vault.
+        /// </summary>
+        public const string IntegrationTestEnvironment = "IntegrationTest";
+
+        public const string LocalEnvironment = "Local";
+
+        public static bool UsesGenericOidc(this IConfiguration configuration) =>
+            string.Equals(
+                configuration[ProviderKey],
+                OidcProvider,
+                StringComparison.OrdinalIgnoreCase
+            );
+
+        /// <summary>
+        /// Whether a plain-HTTP authority is tolerated. Only where the issuer is
+        /// necessarily local: a developer's machine, or the integration test network.
+        ///
+        /// Everywhere else an <c>http://</c> authority fails at startup, so pointing a
+        /// real deployment at an unencrypted issuer is not something that can happen by
+        /// leaking an environment variable.
+        /// </summary>
+        public static bool AllowsInsecureMetadata(this IHostEnvironment environment) =>
+            environment.IsEnvironment(LocalEnvironment)
+            || environment.IsEnvironment(IntegrationTestEnvironment);
+
+        /// <summary>
+        /// Registers JWT bearer authentication.
+        /// </summary>
+        public static IServiceCollection ConfigureAuthentication(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            IHostEnvironment environment
+        )
+        {
+            services
+                .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddMicrosoftIdentityWebApi(configuration.GetSection("AzureAd"))
+                .EnableTokenAcquisitionToCallDownstreamApi()
+                .AddInMemoryTokenCaches();
+
+            if (configuration.UsesGenericOidc())
+            {
+                ConfigureGenericOidcOverrides(services, configuration, environment);
+            }
+
+            return services;
+        }
+
+        /// <summary>
+        /// Points token validation at the configured OpenID issuer.
+        ///
+        /// AddMicrosoftIdentityWebApi installs an AadIssuerValidator, which expects
+        /// Entra-shaped issuers and performs instance discovery against
+        /// login.microsoftonline.com. That validator is replaced with plain issuer
+        /// validation against the issuer's discovery document.
+        ///
+        /// This is deliberately split across the two options phases:
+        ///
+        ///   Configure     - the authority and RequireHttpsMetadata, because
+        ///                   JwtBearerPostConfigureOptions throws
+        ///                   "MetadataAddress or Authority must use HTTPS" for a plain
+        ///                   HTTP authority, and it runs before any post-configuration
+        ///                   we could register.
+        ///   PostConfigure - clearing the issuer validator, because
+        ///                   Microsoft.Identity.Web installs it during
+        ///                   post-configuration and the last registration wins.
+        /// </summary>
+        private static void ConfigureGenericOidcOverrides(
+            IServiceCollection services,
+            IConfiguration configuration,
+            IHostEnvironment environment
+        )
+        {
+            string authority =
+                configuration["AzureAd:Authority"]
+                ?? throw new InvalidOperationException(
+                    $"AzureAd:Authority is required when {ProviderKey} is {OidcProvider}"
+                );
+            string audience =
+                configuration["AzureAd:ClientId"]
+                ?? throw new InvalidOperationException(
+                    $"AzureAd:ClientId is required when {ProviderKey} is {OidcProvider}"
+                );
+
+            bool allowInsecureMetadata = environment.AllowsInsecureMetadata();
+            if (
+                !allowInsecureMetadata
+                && !authority.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                throw new InvalidOperationException(
+                    $"AzureAd:Authority must use HTTPS in the {environment.EnvironmentName} "
+                        + $"environment, but was '{authority}'. Plain HTTP is only accepted in "
+                        + $"the {LocalEnvironment} and {IntegrationTestEnvironment} environments."
+                );
+            }
+
+            services.Configure<JwtBearerOptions>(
+                JwtBearerDefaults.AuthenticationScheme,
+                options =>
+                {
+                    options.Authority = authority;
+                    options.Audience = audience;
+                    options.RequireHttpsMetadata = !allowInsecureMetadata;
+                }
+            );
+
+            services.PostConfigure<JwtBearerOptions>(
+                JwtBearerDefaults.AuthenticationScheme,
+                options =>
+                {
+                    var parameters = options.TokenValidationParameters;
+                    parameters.ValidateIssuer = true;
+                    parameters.ValidateAudience = true;
+                    parameters.ValidateLifetime = true;
+                    parameters.ValidAudience = audience;
+                    parameters.ValidAudiences = [audience];
+                    // Drop the Entra-specific issuer validator; the issuer is taken from
+                    // the provider's discovery document instead.
+                    parameters.IssuerValidator = null;
+                    parameters.ValidIssuers = null;
+                }
+            );
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -10,10 +10,8 @@ using api.Services.ResultHandlers.AnalysisResultHandlers;
 using api.Services.ResultHandlers.WorkflowResultHandlers;
 using api.Utilities;
 using Azure.Core;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Identity.Web;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -124,11 +122,7 @@ builder
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.ConfigureSwagger(builder.Configuration);
 
-builder
-    .Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-    .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))
-    .EnableTokenAcquisitionToCallDownstreamApi()
-    .AddInMemoryTokenCaches();
+builder.Services.ConfigureAuthentication(builder.Configuration, builder.Environment);
 
 builder.Services.ConfigureJwtBearerLogging();
 
@@ -211,6 +205,16 @@ app.MapGet(
                 {
                     ClientId = configuration["AzureAd:ClientId"] ?? "",
                     TenantId = configuration["AzureAd:TenantId"] ?? "",
+                    // The SPA builds its own authority from TenantId when the provider
+                    // is Entra ID. Serving both here lets it point at any other
+                    // OpenID issuer without a rebuild.
+                    Authority = configuration["AzureAd:Authority"] ?? "",
+                },
+                Authentication = new
+                {
+                    Provider =
+                        configuration[api.Configurations.AuthenticationConfigurations.ProviderKey]
+                        ?? api.Configurations.AuthenticationConfigurations.EntraIdProvider,
                 },
                 BasePath = (configuration["ApiBaseRoute"] ?? "").TrimEnd('/'),
                 FlotillaBaseUrl = (configuration["FlotillaBaseUrl"] ?? "").TrimEnd('/'),

--- a/api/appsettings.IntegrationTest.json
+++ b/api/appsettings.IntegrationTest.json
@@ -1,0 +1,27 @@
+{
+  "Authentication": {
+    "Provider": "Oidc"
+  },
+  "AzureAd": {
+    "ClientId": "sara-test",
+    "Authority": "http://keycloak:8080/realms/robotics",
+    "AllowedAuthMethods": ["WorkloadIdentity"]
+  },
+  "KeyVault": {
+    "UseKeyVault": false
+  },
+  "OpenTelemetry": {
+    "Enabled": false
+  },
+  "AllowedHosts": "*",
+  "AllowedOrigins": ["http://localhost:3001", "https://localhost:3001"],
+  "Database": {
+    "UseInMemoryDatabase": false,
+    "AllowedAuthMethods": ["ConnectionString"]
+  },
+  "EndpointConfig": {
+    "DefaultScheme": "http",
+    "DefaultHost": "localhost",
+    "DefaultPort": 8100
+  }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,24 @@
 services:
+  # Local OpenID Connect issuer, an alternative to Microsoft Entra ID.
+  #
+  # Start with:  docker compose --profile keycloak up keycloak
+  # Kept behind a profile so the default `docker compose up` is unchanged.
+  #
+  # The realm is the one the armada integration tests use, so that a local run and a
+  # CI run exercise the same clients, scopes and roles. armada is expected to sit
+  # beside this repository; override with KEYCLOAK_REALM_DIR if it does not.
+  keycloak:
+    profiles: ["keycloak"]
+    image: quay.io/keycloak/keycloak:26.4
+    command: ["start-dev", "--import-realm"]
+    ports:
+      - "8080:8080"
+    environment:
+      - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+      - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
+    volumes:
+      - ${KEYCLOAK_REALM_DIR:-../armada/robotics_integration_tests/custom_realms}:/opt/keycloak/data/import:ro
+
   sara:
     build:
       context: .


### PR DESCRIPTION
Lets the API validate access tokens against any conformant OpenID Connect provider, not only Azure Entra ID.

Third of four PRs — equinor/isar#1158, equinor/flotilla#2863, this, equinor/armada#87. Mirrors the flotilla change; that PR carries the fuller rationale.

## `Authentication:Provider`

| Value | Issuer |
| --- | --- |
| `EntraId` (default) | Microsoft Entra ID, unchanged |
| `Oidc` | Any conformant OpenID Connect issuer, at `AzureAd:Authority` |

**Not an authentication bypass**: issuer, audience, signature, lifetime and roles are validated under either value. What is gated instead is transport security — an `http://` authority is accepted only in `Local` and `IntegrationTest`, and throws at startup anywhere else.

The override spans both options phases, which is not optional: `JwtBearerPostConfigureOptions` rejects a plain-HTTP authority and runs before any post-configuration we can register, while Microsoft.Identity.Web installs its Entra-specific `AadIssuerValidator` *during* post-configuration, so only a later post-configure can remove it. `ConfigureJwtBearerLogging` replaces `options.Events` wholesale but touches neither the authority nor the validation parameters, so it composes regardless of ordering.

## `/api/config` gains `authority` and `provider`

The SPA derives its authority from the tenant ID, which only makes sense for Entra. Serving both means the frontend can be repointed at another issuer without a rebuild when that work is picked up — five lines now instead of a second round of backend changes later.

The endpoint was verified at runtime to still return everything main added to it: `clientId`, `tenantId`, `authority`, `provider`, `basePath`, `flotillaBaseUrl`, `argoWorkflowsBaseUrl`, `argoWorkflowsNamespace`.

## SARA had no endpoint-level authentication test

flotilla and ISAR both have one. Added, covering every endpoint. All of them already carry `[Authorize]`, so it passed unchanged — the gap was in verification, not in the code.

## Verification

API run with `ASPNETCORE_ENVIRONMENT=Local` and `Authentication__Provider=Oidc` against a real Keycloak realm:

| `GET /api/analysis` | Result |
| --- | --- |
| no token | 401 |
| valid token, `aud=sara-test` | 200 |
| wrong audience (`aud=flotilla-test`) | 401 |

`dotnet build -warnaserror` and `dotnet csharpier check` clean; **124/124 tests pass**. Also confirmed end to end in the full armada integration suite.

## What this does not do

Starting the API this way first failed with *"No usable runtime Azure credential could be constructed."*

`AzureAd:AllowedAuthMethods` is a **separate concern**: it selects the `TokenCredential` used for blob storage and Microsoft Graph. Both `AzureCliBootstrap` and `ClientSecret` need Azure credentials at startup, so the documented setup selects `WorkloadIdentity`, which is constructed lazily — but any code path actually reaching blob storage or e-mail will still fail.

So this makes SARA's **sign-in** free of Azure, not SARA. The README says that rather than implying more. Genuinely removing the rest means `Services/BlobStorageService.cs` — which also generates SAS tokens, the hard part — and `Services/EmailService.cs` (Graph → SMTP), both well out of scope here.

## Note for reviewers

Inert until armada opts in: `Authentication:Provider` is unset everywhere except `appsettings.IntegrationTest.json`. The frontend still signs in against Entra ID.

Replaces #449, which took the same approach against a bespoke oauth2-mock-server issuer.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [x] A test has been written
- [x] Relevant issues are linked
- [x] Remaining work is documented in issues
- [x] The changes do not introduce dead code as unused imports, functions etc.
