### PR TITLE
ACR migration: Dual-push images to per-env robotics ACRs alongside Aurora

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -79,6 +79,32 @@ jobs:
       registry_password: ${{ secrets.ROBOTICS_AURORAPRODACR_PASSWORD }}
       registry_username: ${{ secrets.ROBOTICS_AURORAPRODACR_USERNAME }}
 
+  build-and-push-latest-release-images-to-robotics-staging-registry:
+    name: Build and push latest release images to robotics staging registry
+    uses: equinor/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@main
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - image_name: robotics/sara
+            path_to_dockerfile: Dockerfile
+            path_to_context: .
+          - image_name: robotics/workflow-notifier
+            path_to_dockerfile: workflow-notifier/Dockerfile
+            path_to_context: workflow-notifier
+    with:
+      registry: roboticsstagingacr.azurecr.io
+      image_name: ${{ matrix.image_name }}
+      tag: "${{ github.event.release.tag_name }}"
+      secondary_tag: latest
+      path_to_dockerfile: ${{ matrix.path_to_dockerfile }}
+      path_to_context: ${{ matrix.path_to_context }}
+    secrets:
+      registry_password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
+      registry_username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
+
   deploy:
     name: Update deployment in Staging
     needs: build-and-push-latest-release-images-to-aurora-prod-registry

--- a/.github/workflows/promote_to_production.yaml
+++ b/.github/workflows/promote_to_production.yaml
@@ -50,9 +50,38 @@ jobs:
       working_directory: api
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+  copy-images-to-robotics-prod-registry:
+    name: Copy staging images to robotics prod registry
+    needs: get_staging_version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image_name: [robotics/sara, robotics/workflow-notifier]
+    steps:
+      - name: Log in to robotics staging registry
+        uses: docker/login-action@v3
+        with:
+          registry: roboticsstagingacr.azurecr.io
+          username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
+          password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
+
+      - name: Log in to robotics prod registry
+        uses: docker/login-action@v3
+        with:
+          registry: roboticsprodacr.azurecr.io
+          username: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_USERNAME }}
+          password: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_PASSWORD }}
+
+      - name: Copy image from staging to prod registry
+        run: |
+          docker buildx imagetools create \
+            --tag roboticsprodacr.azurecr.io/${{ matrix.image_name }}:${{ needs.get_staging_version.outputs.versionTag }} \
+            --tag roboticsprodacr.azurecr.io/${{ matrix.image_name }}:latest \
+            roboticsstagingacr.azurecr.io/${{ matrix.image_name }}:${{ needs.get_staging_version.outputs.versionTag }}
+
   deploy:
     name: Update deployment in Production
-    needs: get_staging_version
+    needs: [get_staging_version, copy-images-to-robotics-prod-registry]
     uses: equinor/armada/.github/workflows/update_kubernetes_deployment.yml@main
     strategy:
       max-parallel: 1


### PR DESCRIPTION
Migrates image builds off Aurora ACR to per-env robotics ACRs alongside the existing Aurora jobs during migration.

**Model**

- `deploy_to_staging.yml`: on release, also push `robotics/sara` and `robotics/workflow-notifier` images to `roboticsstagingacr.azurecr.io`.
- `promote_to_production.yaml`: adds a matrixed `copy-images-to-robotics-prod-registry` job that uses `docker buildx imagetools create` to copy each image tag from `roboticsstagingacr` \u2192 `roboticsprodacr` (no rebuild), then the existing deploy job patches the production overlay.

Dev workflow is unchanged \u2014 already dual-pushes to ghcr and Aurora dev. Analytics dev overlay will retarget from `auroradevacr` to `ghcr.io` in a follow-up PR on equinor/analytics-infrastructure.

Aurora push jobs are preserved during migration and will be dropped in a follow-up PR after all analytics overlays retarget to robotics ACRs.

Requires repo secrets: `ROBOTICS_ROBOTICS{STAGING,PROD}ACR_{USERNAME,PASSWORD}` \u2014 provisioned by `automation/aks/provision-acr-push-tokens.sh` in equinor/robotics-infrastructure#1054.

Part of container registry migration off Aurora (equinor/robotics-infrastructure#1009).