### PR TITLE
CI: Update dev overlay from ghcr instead of auroradevacr

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -98,7 +98,7 @@ jobs:
 
   deploy:
     name: Update deployment in Development
-    needs: [build-and-push-dev-images-to-aurora-dev-registry, get-short-sha, get-short-sha-for-workflow-notifier-folder]
+    needs: [build-and-push-dev-images-to-ghcr, get-short-sha, get-short-sha-for-workflow-notifier-folder]
     uses: equinor/armada/.github/workflows/update_kubernetes_deployment.yml@main
     permissions:
       contents: read
@@ -106,13 +106,13 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - image_name: robotics/sara
+          - image_name: ${{ github.repository }}
             short_sha_output: ${{ needs.get-short-sha.outputs.tag }}
-          - image_name: robotics/workflow-notifier
+          - image_name: ${{ github.repository }}-workflow-notifier
             short_sha_output: ${{ needs.get-short-sha-for-workflow-notifier-folder.outputs.tag }}
     with:
       environment: development
-      registry: auroradevacr.azurecr.io
+      registry: ghcr.io
       image_name: ${{ matrix.image_name }}
       tag: "dev.${{ matrix.short_sha_output }}"
       author_email: ${{ github.event.head_commit.author.email }}


### PR DESCRIPTION
## Summary
- Point the `Update deployment in Development` job at the ghcr build instead of the auroradevacr build (`registry`, `image_name`, and `needs` updated).

## Why
Pairs with equinor/analytics-infrastructure#319 which retargets the dev overlay's `newName` for every SARA image to `ghcr.io/equinor/*`. Until this merges *and* #319 is merged, next dev push will fail the `Update deployment` step because armada looks for the old `auroradevacr.azurecr.io/robotics/*` string, which #319 replaced. Failure is non-destructive.

Follow-up cleanup (not in this PR): the parallel aurora-dev build job is now dead code (Aurora dev overlay will also pull from ghcr after #319) and can be deleted.