### PR TITLE
CI: Remove dead auroradevacr push job from dev workflow

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -67,35 +67,6 @@ jobs:
       registry_password: ${{ secrets.GITHUB_TOKEN }}
       registry_username: ${{ github.actor }}
 
-  build-and-push-dev-images-to-aurora-dev-registry:
-    name: Build and push dev images to aurora dev registry
-    needs: [get-short-sha, get-short-sha-for-workflow-notifier-folder]
-    uses: equinor/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@main
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        include:
-          - image_name: robotics/sara
-            path_to_dockerfile: Dockerfile
-            path_to_context: .
-            short_sha_output: ${{ needs.get-short-sha.outputs.tag }}
-          - image_name: robotics/workflow-notifier
-            path_to_dockerfile: workflow-notifier/Dockerfile
-            path_to_context: workflow-notifier
-            short_sha_output: ${{ needs.get-short-sha-for-workflow-notifier-folder.outputs.tag }}
-    with:
-      registry: auroradevacr.azurecr.io
-      image_name: ${{ matrix.image_name }}
-      tag: "dev.${{ matrix.short_sha_output }}"
-      secondary_tag: dev
-      path_to_dockerfile: ${{ matrix.path_to_dockerfile }}
-      path_to_context: ${{ matrix.path_to_context }}
-    secrets:
-      registry_password: ${{ secrets.ROBOTICS_AURORADEVACR_PASSWORD }}
-      registry_username: ${{ secrets.ROBOTICS_AURORADEVACR_USERNAME }}
-
   deploy:
     name: Update deployment in Development
     needs: [build-and-push-dev-images-to-ghcr, get-short-sha, get-short-sha-for-workflow-notifier-folder]


### PR DESCRIPTION
The dev overlay was retargeted to ghcr; the auroradevacr push job is dead code. Same cleanup as sara-timeseries#117 / sara-constant-level-oiler#81 / sara-utilities#9 / sara-rain-drop-detector#20.